### PR TITLE
refactor: consolidate array metadata and simplify NDArray constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ docs/.vitepress/dist
 docs/changelog.md
 docs/contributing.md
 
+benchmark
+announcement
+.agents
+skills-lock.json
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,7 +265,7 @@ $arr->add(5)     ───────▶   ndarray_add      ──────�
      │                    C ABI boundary                    │
      │                           │                          │
      ▼                           ▼                          ▼
-NDArray obj              ViewMetadata              NDArrayWrapper
+NDArray obj              ArrayMetadata              NDArrayWrapper
 (handle, shape)          (offset, strides)         (actual data)
 ```
 

--- a/include/ndarray_php.h
+++ b/include/ndarray_php.h
@@ -43,7 +43,7 @@ typedef struct NdArrayHandle {
  *
  * This struct bundles all the metadata needed to describe a view - offset, shape, strides, and ndim.
  */
-typedef struct ViewMetadata {
+typedef struct ArrayMetadata {
   /**
    * Offset into the underlying data buffer (in elements, not bytes)
    */
@@ -60,7 +60,7 @@ typedef struct ViewMetadata {
    * Number of dimensions
    */
   uintptr_t ndim;
-} ViewMetadata;
+} ArrayMetadata;
 
 /**
  * Get the last error message.
@@ -74,9 +74,9 @@ uintptr_t ndarray_get_last_error(char *buf, uintptr_t len);
  * Add two arrays.
  */
 int32_t ndarray_add(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -87,7 +87,7 @@ int32_t ndarray_add(const struct NdArrayHandle *a,
  * Add a scalar to an array.
  */
 int32_t ndarray_add_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -99,9 +99,9 @@ int32_t ndarray_add_scalar(const struct NdArrayHandle *a,
  * Divide two arrays.
  */
 int32_t ndarray_div(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -112,7 +112,7 @@ int32_t ndarray_div(const struct NdArrayHandle *a,
  * Divide an array by a scalar.
  */
 int32_t ndarray_div_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -125,9 +125,9 @@ int32_t ndarray_div_scalar(const struct NdArrayHandle *a,
  * Returns an array of the same shape containing the smaller value at each position.
  */
 int32_t ndarray_minimum(const struct NdArrayHandle *a,
-                        const struct ViewMetadata *a_meta,
+                        const struct ArrayMetadata *a_meta,
                         const struct NdArrayHandle *b,
-                        const struct ViewMetadata *b_meta,
+                        const struct ArrayMetadata *b_meta,
                         struct NdArrayHandle **out,
                         uint8_t *out_dtype_ptr,
                         uintptr_t *out_ndim,
@@ -139,9 +139,9 @@ int32_t ndarray_minimum(const struct NdArrayHandle *a,
  * Returns an array of the same shape containing the larger value at each position.
  */
 int32_t ndarray_maximum(const struct NdArrayHandle *a,
-                        const struct ViewMetadata *a_meta,
+                        const struct ArrayMetadata *a_meta,
                         const struct NdArrayHandle *b,
-                        const struct ViewMetadata *b_meta,
+                        const struct ArrayMetadata *b_meta,
                         struct NdArrayHandle **out,
                         uint8_t *out_dtype_ptr,
                         uintptr_t *out_ndim,
@@ -152,9 +152,9 @@ int32_t ndarray_maximum(const struct NdArrayHandle *a,
  * Multiply two arrays.
  */
 int32_t ndarray_mul(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -165,7 +165,7 @@ int32_t ndarray_mul(const struct NdArrayHandle *a,
  * Multiply an array by a scalar.
  */
 int32_t ndarray_mul_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -177,9 +177,9 @@ int32_t ndarray_mul_scalar(const struct NdArrayHandle *a,
  * Compute the remainder of two arrays.
  */
 int32_t ndarray_rem(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -190,7 +190,7 @@ int32_t ndarray_rem(const struct NdArrayHandle *a,
  * Compute the remainder of an array by a scalar.
  */
 int32_t ndarray_rem_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -202,9 +202,9 @@ int32_t ndarray_rem_scalar(const struct NdArrayHandle *a,
  * Subtract two arrays.
  */
 int32_t ndarray_sub(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -215,7 +215,7 @@ int32_t ndarray_sub(const struct NdArrayHandle *a,
  * Subtract a scalar from an array.
  */
 int32_t ndarray_sub_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -245,7 +245,7 @@ int32_t ndarray_create(const void *data,
  * Create a deep copy of an array view.
  */
 int32_t ndarray_copy(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out_handle);
 
 /**
@@ -260,7 +260,7 @@ int32_t ndarray_copy(const struct NdArrayHandle *handle,
  * * `out_len` - Output: actual number of elements copied
  */
 int32_t ndarray_get_data(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          uintptr_t start,
                          uintptr_t len,
                          void *out_data,
@@ -282,16 +282,16 @@ int32_t ndarray_free(struct NdArrayHandle *handle);
  * For numeric types: writes the native value (up to 8 bytes).
  */
 int32_t ndarray_as_scalar(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           void *out_value);
 
 /**
  * Compute the bitwise AND of two arrays.
  */
 int32_t ndarray_bitand(const struct NdArrayHandle *a,
-                       const struct ViewMetadata *a_meta,
+                       const struct ArrayMetadata *a_meta,
                        const struct NdArrayHandle *b,
-                       const struct ViewMetadata *b_meta,
+                       const struct ArrayMetadata *b_meta,
                        struct NdArrayHandle **out,
                        uint8_t *out_dtype_ptr,
                        uintptr_t *out_ndim,
@@ -302,7 +302,7 @@ int32_t ndarray_bitand(const struct NdArrayHandle *a,
  * Compute the bitwise AND of an array and a scalar.
  */
 int32_t ndarray_bitand_scalar(const struct NdArrayHandle *a,
-                              const struct ViewMetadata *a_meta,
+                              const struct ArrayMetadata *a_meta,
                               int64_t scalar,
                               struct NdArrayHandle **out,
                               uint8_t *out_dtype,
@@ -314,9 +314,9 @@ int32_t ndarray_bitand_scalar(const struct NdArrayHandle *a,
  * Compute the bitwise OR of two arrays.
  */
 int32_t ndarray_bitor(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *a_meta,
+                      const struct ArrayMetadata *a_meta,
                       const struct NdArrayHandle *b,
-                      const struct ViewMetadata *b_meta,
+                      const struct ArrayMetadata *b_meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype_ptr,
                       uintptr_t *out_ndim,
@@ -327,7 +327,7 @@ int32_t ndarray_bitor(const struct NdArrayHandle *a,
  * Compute the bitwise OR of an array and a scalar.
  */
 int32_t ndarray_bitor_scalar(const struct NdArrayHandle *a,
-                             const struct ViewMetadata *a_meta,
+                             const struct ArrayMetadata *a_meta,
                              int64_t scalar,
                              struct NdArrayHandle **out,
                              uint8_t *out_dtype,
@@ -339,9 +339,9 @@ int32_t ndarray_bitor_scalar(const struct NdArrayHandle *a,
  * Compute the bitwise XOR of two arrays.
  */
 int32_t ndarray_bitxor(const struct NdArrayHandle *a,
-                       const struct ViewMetadata *a_meta,
+                       const struct ArrayMetadata *a_meta,
                        const struct NdArrayHandle *b,
-                       const struct ViewMetadata *b_meta,
+                       const struct ArrayMetadata *b_meta,
                        struct NdArrayHandle **out,
                        uint8_t *out_dtype_ptr,
                        uintptr_t *out_ndim,
@@ -352,7 +352,7 @@ int32_t ndarray_bitxor(const struct NdArrayHandle *a,
  * Compute the bitwise XOR of an array by a scalar.
  */
 int32_t ndarray_bitxor_scalar(const struct NdArrayHandle *a,
-                              const struct ViewMetadata *a_meta,
+                              const struct ArrayMetadata *a_meta,
                               int64_t scalar,
                               struct NdArrayHandle **out,
                               uint8_t *out_dtype,
@@ -364,9 +364,9 @@ int32_t ndarray_bitxor_scalar(const struct NdArrayHandle *a,
  * Compute the left shift of two arrays.
  */
 int32_t ndarray_left_shift(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            const struct NdArrayHandle *b,
-                           const struct ViewMetadata *b_meta,
+                           const struct ArrayMetadata *b_meta,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype_ptr,
                            uintptr_t *out_ndim,
@@ -377,7 +377,7 @@ int32_t ndarray_left_shift(const struct NdArrayHandle *a,
  * Compute the left shift of an array by a scalar.
  */
 int32_t ndarray_left_shift_scalar(const struct NdArrayHandle *a,
-                                  const struct ViewMetadata *a_meta,
+                                  const struct ArrayMetadata *a_meta,
                                   int64_t scalar,
                                   struct NdArrayHandle **out,
                                   uint8_t *out_dtype,
@@ -389,9 +389,9 @@ int32_t ndarray_left_shift_scalar(const struct NdArrayHandle *a,
  * Compute the right shift of two arrays.
  */
 int32_t ndarray_right_shift(const struct NdArrayHandle *a,
-                            const struct ViewMetadata *a_meta,
+                            const struct ArrayMetadata *a_meta,
                             const struct NdArrayHandle *b,
-                            const struct ViewMetadata *b_meta,
+                            const struct ArrayMetadata *b_meta,
                             struct NdArrayHandle **out,
                             uint8_t *out_dtype_ptr,
                             uintptr_t *out_ndim,
@@ -402,7 +402,7 @@ int32_t ndarray_right_shift(const struct NdArrayHandle *a,
  * Right shift with scalar.
  */
 int32_t ndarray_right_shift_scalar(const struct NdArrayHandle *a,
-                                   const struct ViewMetadata *a_meta,
+                                   const struct ArrayMetadata *a_meta,
                                    int64_t scalar,
                                    struct NdArrayHandle **out,
                                    uint8_t *out_dtype,
@@ -415,7 +415,7 @@ int32_t ndarray_right_shift_scalar(const struct NdArrayHandle *a,
  *
  */
 int32_t ndarray_astype(const struct NdArrayHandle *handle,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        int32_t target_dtype,
                        struct NdArrayHandle **out);
 
@@ -423,9 +423,9 @@ int32_t ndarray_astype(const struct NdArrayHandle *handle,
  * Element-wise equal comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_eq(const struct NdArrayHandle *a,
-                   const struct ViewMetadata *a_meta,
+                   const struct ArrayMetadata *a_meta,
                    const struct NdArrayHandle *b,
-                   const struct ViewMetadata *b_meta,
+                   const struct ArrayMetadata *b_meta,
                    struct NdArrayHandle **out,
                    uint8_t *out_dtype_ptr,
                    uintptr_t *out_ndim,
@@ -436,7 +436,7 @@ int32_t ndarray_eq(const struct NdArrayHandle *a,
  * Element-wise equal comparison with scalar. Returns Bool array.
  */
 int32_t ndarray_eq_scalar(const struct NdArrayHandle *a,
-                          const struct ViewMetadata *a_meta,
+                          const struct ArrayMetadata *a_meta,
                           double scalar,
                           struct NdArrayHandle **out,
                           uint8_t *out_dtype,
@@ -448,9 +448,9 @@ int32_t ndarray_eq_scalar(const struct NdArrayHandle *a,
  * Element-wise greater-than comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_gt(const struct NdArrayHandle *a,
-                   const struct ViewMetadata *a_meta,
+                   const struct ArrayMetadata *a_meta,
                    const struct NdArrayHandle *b,
-                   const struct ViewMetadata *b_meta,
+                   const struct ArrayMetadata *b_meta,
                    struct NdArrayHandle **out,
                    uint8_t *out_dtype_ptr,
                    uintptr_t *out_ndim,
@@ -458,7 +458,7 @@ int32_t ndarray_gt(const struct NdArrayHandle *a,
                    uintptr_t max_ndim);
 
 int32_t ndarray_gt_scalar(const struct NdArrayHandle *a,
-                          const struct ViewMetadata *a_meta,
+                          const struct ArrayMetadata *a_meta,
                           double scalar,
                           struct NdArrayHandle **out,
                           uint8_t *out_dtype,
@@ -470,9 +470,9 @@ int32_t ndarray_gt_scalar(const struct NdArrayHandle *a,
  * Element-wise greater-or-equal comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_gte(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -480,7 +480,7 @@ int32_t ndarray_gte(const struct NdArrayHandle *a,
                     uintptr_t max_ndim);
 
 int32_t ndarray_gte_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -492,9 +492,9 @@ int32_t ndarray_gte_scalar(const struct NdArrayHandle *a,
  * Element-wise less-than comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_lt(const struct NdArrayHandle *a,
-                   const struct ViewMetadata *a_meta,
+                   const struct ArrayMetadata *a_meta,
                    const struct NdArrayHandle *b,
-                   const struct ViewMetadata *b_meta,
+                   const struct ArrayMetadata *b_meta,
                    struct NdArrayHandle **out,
                    uint8_t *out_dtype_ptr,
                    uintptr_t *out_ndim,
@@ -502,7 +502,7 @@ int32_t ndarray_lt(const struct NdArrayHandle *a,
                    uintptr_t max_ndim);
 
 int32_t ndarray_lt_scalar(const struct NdArrayHandle *a,
-                          const struct ViewMetadata *a_meta,
+                          const struct ArrayMetadata *a_meta,
                           double scalar,
                           struct NdArrayHandle **out,
                           uint8_t *out_dtype,
@@ -514,9 +514,9 @@ int32_t ndarray_lt_scalar(const struct NdArrayHandle *a,
  * Element-wise less-or-equal comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_lte(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -524,7 +524,7 @@ int32_t ndarray_lte(const struct NdArrayHandle *a,
                     uintptr_t max_ndim);
 
 int32_t ndarray_lte_scalar(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            double scalar,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
@@ -536,9 +536,9 @@ int32_t ndarray_lte_scalar(const struct NdArrayHandle *a,
  * Element-wise not-equal comparison with broadcasting. Returns Bool array.
  */
 int32_t ndarray_ne(const struct NdArrayHandle *a,
-                   const struct ViewMetadata *a_meta,
+                   const struct ArrayMetadata *a_meta,
                    const struct NdArrayHandle *b,
-                   const struct ViewMetadata *b_meta,
+                   const struct ArrayMetadata *b_meta,
                    struct NdArrayHandle **out,
                    uint8_t *out_dtype_ptr,
                    uintptr_t *out_ndim,
@@ -546,7 +546,7 @@ int32_t ndarray_ne(const struct NdArrayHandle *a,
                    uintptr_t max_ndim);
 
 int32_t ndarray_ne_scalar(const struct NdArrayHandle *a,
-                          const struct ViewMetadata *a_meta,
+                          const struct ArrayMetadata *a_meta,
                           double scalar,
                           struct NdArrayHandle **out,
                           uint8_t *out_dtype,
@@ -714,9 +714,9 @@ int32_t ndarray_zeros(const uintptr_t *shape,
  * * `src_meta` - Source view metadata
  */
 int32_t ndarray_assign(const struct NdArrayHandle *dst,
-                       const struct ViewMetadata *dst_meta,
+                       const struct ArrayMetadata *dst_meta,
                        const struct NdArrayHandle *src,
-                       const struct ViewMetadata *src_meta);
+                       const struct ArrayMetadata *src_meta);
 
 /**
  * Fill a slice with a value.
@@ -727,7 +727,7 @@ int32_t ndarray_assign(const struct NdArrayHandle *dst,
  * * `value` - Pointer to the fill value (type depends on array dtype)
  */
 int32_t ndarray_fill(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      const void *value);
 
 /**
@@ -748,9 +748,9 @@ int32_t ndarray_get_element(const struct NdArrayHandle *handle,
  * Put values by flattened logical indices.
  */
 int32_t ndarray_put(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     const struct NdArrayHandle *indices_handle,
-                    const struct ViewMetadata *indices_meta,
+                    const struct ArrayMetadata *indices_meta,
                     const void *values,
                     uintptr_t values_len,
                     double scalar_value,
@@ -761,9 +761,9 @@ int32_t ndarray_put(const struct NdArrayHandle *handle,
  * Scatter values along an axis and return a mutated copy.
  */
 int32_t ndarray_put_along_axis(const struct NdArrayHandle *handle,
-                               const struct ViewMetadata *meta,
+                               const struct ArrayMetadata *meta,
                                const struct NdArrayHandle *indices_handle,
-                               const struct ViewMetadata *indices_meta,
+                               const struct ArrayMetadata *indices_meta,
                                int32_t axis,
                                const void *values,
                                uintptr_t values_len,
@@ -775,9 +775,9 @@ int32_t ndarray_put_along_axis(const struct NdArrayHandle *handle,
  * Add updates into flattened indices and return a mutated copy.
  */
 int32_t ndarray_scatter_add_flat(const struct NdArrayHandle *handle,
-                                 const struct ViewMetadata *meta,
+                                 const struct ArrayMetadata *meta,
                                  const struct NdArrayHandle *indices_handle,
-                                 const struct ViewMetadata *indices_meta,
+                                 const struct ArrayMetadata *indices_meta,
                                  const void *updates,
                                  uintptr_t updates_len,
                                  double scalar_update,
@@ -800,9 +800,9 @@ int32_t ndarray_set_element(struct NdArrayHandle *handle, uintptr_t flat_index, 
  * Gather values by flattened logical indices.
  */
 int32_t ndarray_take(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      const struct NdArrayHandle *indices_handle,
-                     const struct ViewMetadata *indices_meta,
+                     const struct ArrayMetadata *indices_meta,
                      struct NdArrayHandle **out_handle,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -815,9 +815,9 @@ int32_t ndarray_take(const struct NdArrayHandle *handle,
  * This selects entire slices along the specified axis according to indices.
  */
 int32_t ndarray_take_axis(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           const struct NdArrayHandle *indices_handle,
-                          const struct ViewMetadata *indices_meta,
+                          const struct ArrayMetadata *indices_meta,
                           int32_t axis,
                           struct NdArrayHandle **out_handle,
                           uint8_t *out_dtype,
@@ -829,9 +829,9 @@ int32_t ndarray_take_axis(const struct NdArrayHandle *handle,
  * Gather values using per-position indices along a specific axis.
  */
 int32_t ndarray_take_along_axis(const struct NdArrayHandle *handle,
-                                const struct ViewMetadata *meta,
+                                const struct ArrayMetadata *meta,
                                 const struct NdArrayHandle *indices_handle,
-                                const struct ViewMetadata *indices_meta,
+                                const struct ArrayMetadata *indices_meta,
                                 int32_t axis,
                                 struct NdArrayHandle **out_handle,
                                 uint8_t *out_dtype,
@@ -843,11 +843,11 @@ int32_t ndarray_take_along_axis(const struct NdArrayHandle *handle,
  * Select values from x and y depending on condition.
  */
 int32_t ndarray_where(const struct NdArrayHandle *cond_handle,
-                      const struct ViewMetadata *cond_meta,
+                      const struct ArrayMetadata *cond_meta,
                       const struct NdArrayHandle *x_handle,
-                      const struct ViewMetadata *x_meta,
+                      const struct ArrayMetadata *x_meta,
                       const struct NdArrayHandle *y_handle,
-                      const struct ViewMetadata *y_meta,
+                      const struct ArrayMetadata *y_meta,
                       struct NdArrayHandle **out_handle,
                       uint8_t *out_dtype_ptr,
                       uintptr_t *out_ndim,
@@ -858,7 +858,7 @@ int32_t ndarray_where(const struct NdArrayHandle *cond_handle,
  * Extract diagonal elements.
  */
 int32_t ndarray_diagonal(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          struct NdArrayHandle **out_handle,
                          uint8_t *out_dtype,
                          uintptr_t *out_ndim,
@@ -871,9 +871,9 @@ int32_t ndarray_diagonal(const struct NdArrayHandle *handle,
  * Works directly on views without converting to Vec first.
  */
 int32_t ndarray_dot(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *a_meta,
+                    const struct ArrayMetadata *a_meta,
                     const struct NdArrayHandle *b,
-                    const struct ViewMetadata *b_meta,
+                    const struct ArrayMetadata *b_meta,
                     struct NdArrayHandle **out_handle,
                     uint8_t *out_dtype_ptr,
                     uintptr_t *out_ndim,
@@ -881,14 +881,12 @@ int32_t ndarray_dot(const struct NdArrayHandle *a,
                     uintptr_t max_ndim);
 
 /**
- * Matrix multiplication with full view support.
- *
- * Accepts ViewMetadata for both arrays to properly handle views.
+ * Matrix multiplication.
  */
 int32_t ndarray_matmul(const struct NdArrayHandle *a,
-                       const struct ViewMetadata *a_meta,
+                       const struct ArrayMetadata *a_meta,
                        const struct NdArrayHandle *b,
-                       const struct ViewMetadata *b_meta,
+                       const struct ArrayMetadata *b_meta,
                        struct NdArrayHandle **out_handle,
                        uint8_t *out_dtype_ptr,
                        uintptr_t *out_ndim,
@@ -899,7 +897,7 @@ int32_t ndarray_matmul(const struct NdArrayHandle *a,
  * Compute scalar norm (axis=None).
  */
 int32_t ndarray_norm(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      int32_t ord,
                      void *out_value,
                      uint8_t *out_dtype);
@@ -908,7 +906,7 @@ int32_t ndarray_norm(const struct NdArrayHandle *handle,
  * Compute norm along axis.
  */
 int32_t ndarray_norm_axis(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           int32_t axis,
                           bool keepdims,
                           int32_t ord,
@@ -918,7 +916,7 @@ int32_t ndarray_norm_axis(const struct NdArrayHandle *handle,
  * Compute trace (sum of diagonal elements).
  */
 int32_t ndarray_trace(const struct NdArrayHandle *handle,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out_handle,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -930,9 +928,9 @@ int32_t ndarray_trace(const struct NdArrayHandle *handle,
  * Both arrays are converted to bool first, result is always Bool.
  */
 int32_t ndarray_logical_and(const struct NdArrayHandle *a,
-                            const struct ViewMetadata *a_meta,
+                            const struct ArrayMetadata *a_meta,
                             const struct NdArrayHandle *b,
-                            const struct ViewMetadata *b_meta,
+                            const struct ArrayMetadata *b_meta,
                             struct NdArrayHandle **out,
                             uint8_t *out_dtype_ptr,
                             uintptr_t *out_ndim,
@@ -944,7 +942,7 @@ int32_t ndarray_logical_and(const struct NdArrayHandle *a,
  * Array is converted to bool first, result is always Bool.
  */
 int32_t ndarray_logical_not(const struct NdArrayHandle *a,
-                            const struct ViewMetadata *a_meta,
+                            const struct ArrayMetadata *a_meta,
                             struct NdArrayHandle **out,
                             uint8_t *out_dtype_ptr,
                             uintptr_t *out_ndim,
@@ -956,9 +954,9 @@ int32_t ndarray_logical_not(const struct NdArrayHandle *a,
  * Both arrays are converted to bool first, result is always Bool.
  */
 int32_t ndarray_logical_or(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *a_meta,
+                           const struct ArrayMetadata *a_meta,
                            const struct NdArrayHandle *b,
-                           const struct ViewMetadata *b_meta,
+                           const struct ArrayMetadata *b_meta,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype_ptr,
                            uintptr_t *out_ndim,
@@ -970,9 +968,9 @@ int32_t ndarray_logical_or(const struct NdArrayHandle *a,
  * Both arrays are converted to bool first, result is always Bool.
  */
 int32_t ndarray_logical_xor(const struct NdArrayHandle *a,
-                            const struct ViewMetadata *a_meta,
+                            const struct ArrayMetadata *a_meta,
                             const struct NdArrayHandle *b,
-                            const struct ViewMetadata *b_meta,
+                            const struct ArrayMetadata *b_meta,
                             struct NdArrayHandle **out,
                             uint8_t *out_dtype_ptr,
                             uintptr_t *out_ndim,
@@ -983,7 +981,7 @@ int32_t ndarray_logical_xor(const struct NdArrayHandle *a,
  * Compute cube root element-wise.
  */
 int32_t ndarray_cbrt(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -994,7 +992,7 @@ int32_t ndarray_cbrt(const struct NdArrayHandle *a,
  * Compute exponential element-wise.
  */
 int32_t ndarray_exp(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1005,7 +1003,7 @@ int32_t ndarray_exp(const struct NdArrayHandle *a,
  * Compute 2^x element-wise.
  */
 int32_t ndarray_exp2(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1018,7 +1016,7 @@ int32_t ndarray_exp2(const struct NdArrayHandle *a,
  * This is an alias for log().
  */
 int32_t ndarray_ln(const struct NdArrayHandle *a,
-                   const struct ViewMetadata *meta,
+                   const struct ArrayMetadata *meta,
                    struct NdArrayHandle **out,
                    uint8_t *out_dtype,
                    uintptr_t *out_ndim,
@@ -1031,7 +1029,7 @@ int32_t ndarray_ln(const struct NdArrayHandle *a,
  * More accurate than computing ln(1+x) directly for small x.
  */
 int32_t ndarray_ln_1p(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -1042,7 +1040,7 @@ int32_t ndarray_ln_1p(const struct NdArrayHandle *a,
  * Compute natural logarithm element-wise.
  */
 int32_t ndarray_log(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1053,7 +1051,7 @@ int32_t ndarray_log(const struct NdArrayHandle *a,
  * Compute base-10 logarithm element-wise.
  */
 int32_t ndarray_log10(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -1064,7 +1062,7 @@ int32_t ndarray_log10(const struct NdArrayHandle *a,
  * Compute base-2 logarithm element-wise.
  */
 int32_t ndarray_log2(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1075,7 +1073,7 @@ int32_t ndarray_log2(const struct NdArrayHandle *a,
  * Compute square root element-wise.
  */
 int32_t ndarray_sqrt(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1086,7 +1084,7 @@ int32_t ndarray_sqrt(const struct NdArrayHandle *a,
  * Compute arc cosine element-wise.
  */
 int32_t ndarray_acos(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1097,7 +1095,7 @@ int32_t ndarray_acos(const struct NdArrayHandle *a,
  * Compute arc sine element-wise.
  */
 int32_t ndarray_asin(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1108,7 +1106,7 @@ int32_t ndarray_asin(const struct NdArrayHandle *a,
  * Compute arc tangent element-wise.
  */
 int32_t ndarray_atan(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1119,7 +1117,7 @@ int32_t ndarray_atan(const struct NdArrayHandle *a,
  * Compute cosine element-wise.
  */
 int32_t ndarray_cos(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1130,7 +1128,7 @@ int32_t ndarray_cos(const struct NdArrayHandle *a,
  * Compute hyperbolic cosine element-wise.
  */
 int32_t ndarray_cosh(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1141,7 +1139,7 @@ int32_t ndarray_cosh(const struct NdArrayHandle *a,
  * Compute sine element-wise.
  */
 int32_t ndarray_sin(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1152,7 +1150,7 @@ int32_t ndarray_sin(const struct NdArrayHandle *a,
  * Compute hyperbolic sine element-wise.
  */
 int32_t ndarray_sinh(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1163,7 +1161,7 @@ int32_t ndarray_sinh(const struct NdArrayHandle *a,
  * Compute tangent element-wise.
  */
 int32_t ndarray_tan(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1174,7 +1172,7 @@ int32_t ndarray_tan(const struct NdArrayHandle *a,
  * Compute hyperbolic tangent element-wise.
  */
 int32_t ndarray_tanh(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1185,7 +1183,7 @@ int32_t ndarray_tanh(const struct NdArrayHandle *a,
  * Convert radians to degrees element-wise.
  */
 int32_t ndarray_to_degrees(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *meta,
+                           const struct ArrayMetadata *meta,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
                            uintptr_t *out_ndim,
@@ -1196,7 +1194,7 @@ int32_t ndarray_to_degrees(const struct NdArrayHandle *a,
  * Convert degrees to radians element-wise.
  */
 int32_t ndarray_to_radians(const struct NdArrayHandle *a,
-                           const struct ViewMetadata *meta,
+                           const struct ArrayMetadata *meta,
                            struct NdArrayHandle **out,
                            uint8_t *out_dtype,
                            uintptr_t *out_ndim,
@@ -1207,7 +1205,7 @@ int32_t ndarray_to_radians(const struct NdArrayHandle *a,
  * Compute hypot(a, b) = sqrt(a^2 + b^2) element-wise where b is a scalar.
  */
 int32_t ndarray_hypot(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       double b,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
@@ -1219,7 +1217,7 @@ int32_t ndarray_hypot(const struct NdArrayHandle *a,
  * Compute x^2 element-wise.
  */
 int32_t ndarray_pow2(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1230,7 +1228,7 @@ int32_t ndarray_pow2(const struct NdArrayHandle *a,
  * Compute x^y where y is a float, element-wise.
  */
 int32_t ndarray_powf(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      double exp,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
@@ -1244,7 +1242,7 @@ int32_t ndarray_powf(const struct NdArrayHandle *a,
  * Generally faster than powf for integer exponents.
  */
 int32_t ndarray_powi(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      int32_t exp,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
@@ -1256,7 +1254,7 @@ int32_t ndarray_powi(const struct NdArrayHandle *a,
  * Compute 1/x element-wise.
  */
 int32_t ndarray_recip(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -1267,7 +1265,7 @@ int32_t ndarray_recip(const struct NdArrayHandle *a,
  * Compute ceiling element-wise.
  */
 int32_t ndarray_ceil(const struct NdArrayHandle *a,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      struct NdArrayHandle **out,
                      uint8_t *out_dtype,
                      uintptr_t *out_ndim,
@@ -1278,7 +1276,7 @@ int32_t ndarray_ceil(const struct NdArrayHandle *a,
  * Compute floor element-wise.
  */
 int32_t ndarray_floor(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -1289,7 +1287,7 @@ int32_t ndarray_floor(const struct NdArrayHandle *a,
  * Compute round element-wise.
  */
 int32_t ndarray_round(const struct NdArrayHandle *a,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       struct NdArrayHandle **out,
                       uint8_t *out_dtype,
                       uintptr_t *out_ndim,
@@ -1300,7 +1298,7 @@ int32_t ndarray_round(const struct NdArrayHandle *a,
  * Compute absolute value element-wise.
  */
 int32_t ndarray_abs(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1312,7 +1310,7 @@ int32_t ndarray_abs(const struct NdArrayHandle *a,
  * Not supported for unsigned integers or bool.
  */
 int32_t ndarray_neg(const struct NdArrayHandle *a,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     struct NdArrayHandle **out,
                     uint8_t *out_dtype,
                     uintptr_t *out_ndim,
@@ -1323,7 +1321,7 @@ int32_t ndarray_neg(const struct NdArrayHandle *a,
  * Compute sigmoid element-wise: 1 / (1 + exp(-x)).
  */
 int32_t ndarray_sigmoid(const struct NdArrayHandle *a,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         struct NdArrayHandle **out,
                         uint8_t *out_dtype,
                         uintptr_t *out_ndim,
@@ -1334,7 +1332,7 @@ int32_t ndarray_sigmoid(const struct NdArrayHandle *a,
  * Compute the sign number of each element.
  */
 int32_t ndarray_signum(const struct NdArrayHandle *a,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        struct NdArrayHandle **out,
                        uint8_t *out_dtype,
                        uintptr_t *out_ndim,
@@ -1345,7 +1343,7 @@ int32_t ndarray_signum(const struct NdArrayHandle *a,
  * Softmax along axis. Numerically stable: subtract max before exp.
  */
 int32_t ndarray_softmax(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         int32_t axis,
                         struct NdArrayHandle **out_handle,
                         uint8_t *out_dtype,
@@ -1357,7 +1355,7 @@ int32_t ndarray_softmax(const struct NdArrayHandle *handle,
  * Argmax along axis.
  */
 int32_t ndarray_argmax_axis(const struct NdArrayHandle *handle,
-                            const struct ViewMetadata *meta,
+                            const struct ArrayMetadata *meta,
                             int32_t axis,
                             bool keepdims,
                             struct NdArrayHandle **out_handle,
@@ -1371,7 +1369,7 @@ int32_t ndarray_argmax_axis(const struct NdArrayHandle *handle,
  * Returns Int64 index.
  */
 int32_t ndarray_argmax(const struct NdArrayHandle *handle,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        void *out_value,
                        uint8_t *out_dtype);
 
@@ -1379,7 +1377,7 @@ int32_t ndarray_argmax(const struct NdArrayHandle *handle,
  * Argmin along axis.
  */
 int32_t ndarray_argmin_axis(const struct NdArrayHandle *handle,
-                            const struct ViewMetadata *meta,
+                            const struct ArrayMetadata *meta,
                             int32_t axis,
                             bool keepdims,
                             struct NdArrayHandle **out_handle,
@@ -1393,7 +1391,7 @@ int32_t ndarray_argmin_axis(const struct NdArrayHandle *handle,
  * Returns Int64 index.
  */
 int32_t ndarray_argmin(const struct NdArrayHandle *handle,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        void *out_value,
                        uint8_t *out_dtype);
 
@@ -1401,7 +1399,7 @@ int32_t ndarray_argmin(const struct NdArrayHandle *handle,
  * Count occurrences of non-negative integer values in flattened input.
  */
 int32_t ndarray_bincount(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          uintptr_t minlength,
                          struct NdArrayHandle **out_handle,
                          uint8_t *out_dtype,
@@ -1413,7 +1411,7 @@ int32_t ndarray_bincount(const struct NdArrayHandle *handle,
  * Cumulative product over flattened array. Returns 1D array.
  */
 int32_t ndarray_cumprod(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         struct NdArrayHandle **out_handle,
                         uint8_t *out_dtype,
                         uintptr_t *out_ndim,
@@ -1424,7 +1422,7 @@ int32_t ndarray_cumprod(const struct NdArrayHandle *handle,
  * Cumulative product along axis.
  */
 int32_t ndarray_cumprod_axis(const struct NdArrayHandle *handle,
-                             const struct ViewMetadata *meta,
+                             const struct ArrayMetadata *meta,
                              int32_t axis,
                              struct NdArrayHandle **out_handle,
                              uint8_t *out_dtype,
@@ -1436,7 +1434,7 @@ int32_t ndarray_cumprod_axis(const struct NdArrayHandle *handle,
  * Cumulative sum over flattened array. Returns 1D array.
  */
 int32_t ndarray_cumsum(const struct NdArrayHandle *handle,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        struct NdArrayHandle **out_handle,
                        uint8_t *out_dtype,
                        uintptr_t *out_ndim,
@@ -1447,7 +1445,7 @@ int32_t ndarray_cumsum(const struct NdArrayHandle *handle,
  * Cumulative sum along axis.
  */
 int32_t ndarray_cumsum_axis(const struct NdArrayHandle *handle,
-                            const struct ViewMetadata *meta,
+                            const struct ArrayMetadata *meta,
                             int32_t axis,
                             struct NdArrayHandle **out_handle,
                             uint8_t *out_dtype,
@@ -1459,7 +1457,7 @@ int32_t ndarray_cumsum_axis(const struct NdArrayHandle *handle,
  * Compute the maximum of all elements in the array.
  */
 int32_t ndarray_max(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     void *out_value,
                     uint8_t *out_dtype);
 
@@ -1467,7 +1465,7 @@ int32_t ndarray_max(const struct NdArrayHandle *handle,
  * Compute the maximum along an axis.
  */
 int32_t ndarray_max_axis(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          int32_t axis,
                          bool keepdims,
                          struct NdArrayHandle **out_handle,
@@ -1482,7 +1480,7 @@ int32_t ndarray_max_axis(const struct NdArrayHandle *handle,
  * Returns Float64 regardless of input dtype.
  */
 int32_t ndarray_mean(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      void *out_value,
                      uint8_t *out_dtype);
 
@@ -1490,7 +1488,7 @@ int32_t ndarray_mean(const struct NdArrayHandle *handle,
  * Compute the mean along an axis.
  */
 int32_t ndarray_mean_axis(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           int32_t axis,
                           bool keepdims,
                           struct NdArrayHandle **out_handle,
@@ -1503,7 +1501,7 @@ int32_t ndarray_mean_axis(const struct NdArrayHandle *handle,
  * Compute the minimum of all elements in the array.
  */
 int32_t ndarray_min(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     void *out_value,
                     uint8_t *out_dtype);
 
@@ -1511,7 +1509,7 @@ int32_t ndarray_min(const struct NdArrayHandle *handle,
  * Compute the minimum along an axis.
  */
 int32_t ndarray_min_axis(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          int32_t axis,
                          bool keepdims,
                          struct NdArrayHandle **out_handle,
@@ -1524,7 +1522,7 @@ int32_t ndarray_min_axis(const struct NdArrayHandle *handle,
  * Compute the product of all elements in the array.
  */
 int32_t ndarray_product(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         void *out_value,
                         uint8_t *out_dtype);
 
@@ -1532,7 +1530,7 @@ int32_t ndarray_product(const struct NdArrayHandle *handle,
  * Compute the product along an axis.
  */
 int32_t ndarray_product_axis(const struct NdArrayHandle *handle,
-                             const struct ViewMetadata *meta,
+                             const struct ArrayMetadata *meta,
                              int32_t axis,
                              bool keepdims,
                              struct NdArrayHandle **out_handle,
@@ -1545,7 +1543,7 @@ int32_t ndarray_product_axis(const struct NdArrayHandle *handle,
  * Compute the standard deviation of all elements in the array.
  */
 int32_t ndarray_std(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     double ddof,
                     void *out_value,
                     uint8_t *out_dtype);
@@ -1554,7 +1552,7 @@ int32_t ndarray_std(const struct NdArrayHandle *handle,
  * Compute the standard deviation along an axis in the array.
  */
 int32_t ndarray_std_axis(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          int32_t axis,
                          bool keepdims,
                          double ddof,
@@ -1568,7 +1566,7 @@ int32_t ndarray_std_axis(const struct NdArrayHandle *handle,
  * Compute the sum of all elements in the array.
  */
 int32_t ndarray_sum(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     void *out_value,
                     uint8_t *out_dtype);
 
@@ -1576,7 +1574,7 @@ int32_t ndarray_sum(const struct NdArrayHandle *handle,
  * Compute the sum along an axis.
  */
 int32_t ndarray_sum_axis(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          int32_t axis,
                          bool keepdims,
                          struct NdArrayHandle **out_handle,
@@ -1589,7 +1587,7 @@ int32_t ndarray_sum_axis(const struct NdArrayHandle *handle,
  * Compute the variance of all elements in the array.
  */
 int32_t ndarray_var(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     double ddof,
                     void *out_value,
                     uint8_t *out_dtype);
@@ -1598,7 +1596,7 @@ int32_t ndarray_var(const struct NdArrayHandle *handle,
  * Compute the variance along an axis in the array.
  */
 int32_t ndarray_var_axis(const struct NdArrayHandle *handle,
-                         const struct ViewMetadata *meta,
+                         const struct ArrayMetadata *meta,
                          int32_t axis,
                          bool keepdims,
                          double ddof,
@@ -1612,7 +1610,7 @@ int32_t ndarray_var_axis(const struct NdArrayHandle *handle,
  * Flatten array to 1D.
  */
 int32_t ndarray_flatten(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         struct NdArrayHandle **out_handle,
                         uint8_t *out_dtype,
                         uintptr_t *out_ndim,
@@ -1626,7 +1624,7 @@ int32_t ndarray_flatten(const struct NdArrayHandle *handle,
  * For FFI simplicity, we always return a copy in the specified order.
  */
 int32_t ndarray_ravel(const struct NdArrayHandle *handle,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       int32_t order,
                       struct NdArrayHandle **out_handle,
                       uint8_t *out_dtype,
@@ -1642,7 +1640,7 @@ int32_t ndarray_ravel(const struct NdArrayHandle *handle,
  * * `num_axes` - Number of axes to flip. If 0, flips all axes.
  */
 int32_t ndarray_flip(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      const int64_t *axes,
                      uintptr_t num_axes,
                      struct NdArrayHandle **out_handle,
@@ -1655,7 +1653,7 @@ int32_t ndarray_flip(const struct NdArrayHandle *handle,
  * Pad an array with constant/symmetric/reflect mode.
  */
 int32_t ndarray_pad(const struct NdArrayHandle *handle,
-                    const struct ViewMetadata *meta,
+                    const struct ArrayMetadata *meta,
                     const uintptr_t *pad_width,
                     int32_t mode,
                     const double *constant_values,
@@ -1673,7 +1671,7 @@ int32_t ndarray_pad(const struct NdArrayHandle *handle,
  * Panics if axes are invalid (out of bounds, missing, or duplicated).
  */
 int32_t ndarray_permute(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         const uintptr_t *axes,
                         uintptr_t num_axes,
                         struct NdArrayHandle **out_handle,
@@ -1686,7 +1684,7 @@ int32_t ndarray_permute(const struct NdArrayHandle *handle,
  * Repeat elements of an array.
  */
 int32_t ndarray_repeat(const struct NdArrayHandle *handle,
-                       const struct ViewMetadata *meta,
+                       const struct ArrayMetadata *meta,
                        const uintptr_t *repeats,
                        uintptr_t repeats_len,
                        int32_t axis,
@@ -1700,7 +1698,7 @@ int32_t ndarray_repeat(const struct NdArrayHandle *handle,
  * Reshape array to new shape.
  */
 int32_t ndarray_reshape(const struct NdArrayHandle *handle,
-                        const struct ViewMetadata *meta,
+                        const struct ArrayMetadata *meta,
                         const uintptr_t *new_shape,
                         uintptr_t new_ndim,
                         int32_t order,
@@ -1710,7 +1708,7 @@ int32_t ndarray_reshape(const struct NdArrayHandle *handle,
  * Tile an array by repeating it.
  */
 int32_t ndarray_tile(const struct NdArrayHandle *handle,
-                     const struct ViewMetadata *meta,
+                     const struct ArrayMetadata *meta,
                      const uintptr_t *reps,
                      uintptr_t reps_len,
                      struct NdArrayHandle **out_handle,
@@ -1726,7 +1724,7 @@ int32_t ndarray_tile(const struct NdArrayHandle *handle,
  * For nD arrays, reverses the order of all axes.
  */
 int32_t ndarray_transpose(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           struct NdArrayHandle **out_handle,
                           uint8_t *out_dtype,
                           uintptr_t *out_ndim,
@@ -1737,7 +1735,7 @@ int32_t ndarray_transpose(const struct NdArrayHandle *handle,
  * Compute the argsort along an axis in the array.
  */
 int32_t ndarray_argsort_axis(const struct NdArrayHandle *handle,
-                             const struct ViewMetadata *meta,
+                             const struct ArrayMetadata *meta,
                              int32_t axis,
                              int32_t kind,
                              struct NdArrayHandle **out_handle,
@@ -1750,7 +1748,7 @@ int32_t ndarray_argsort_axis(const struct NdArrayHandle *handle,
  * Compute the argsort of the flattened array.
  */
 int32_t ndarray_argsort_flat(const struct NdArrayHandle *handle,
-                             const struct ViewMetadata *meta,
+                             const struct ArrayMetadata *meta,
                              int32_t kind,
                              struct NdArrayHandle **out_handle,
                              uint8_t *out_dtype,
@@ -1762,7 +1760,7 @@ int32_t ndarray_argsort_flat(const struct NdArrayHandle *handle,
  * Compute the sort along an axis in the array.
  */
 int32_t ndarray_sort_axis(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           int32_t axis,
                           int32_t kind,
                           struct NdArrayHandle **out_handle,
@@ -1775,7 +1773,7 @@ int32_t ndarray_sort_axis(const struct NdArrayHandle *handle,
  * Compute the sort of the flattened array.
  */
 int32_t ndarray_sort_flat(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           int32_t kind,
                           struct NdArrayHandle **out_handle,
                           uint8_t *out_dtype,
@@ -1787,7 +1785,7 @@ int32_t ndarray_sort_flat(const struct NdArrayHandle *handle,
  * Compute the top-k values and indices along an axis in the array.
  */
 int32_t ndarray_topk_axis(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           int32_t axis,
                           uintptr_t k,
                           bool largest,
@@ -1802,7 +1800,7 @@ int32_t ndarray_topk_axis(const struct NdArrayHandle *handle,
  * Compute the top-k values and indices of the flattened array.
  */
 int32_t ndarray_topk_flat(const struct NdArrayHandle *handle,
-                          const struct ViewMetadata *meta,
+                          const struct ArrayMetadata *meta,
                           uintptr_t k,
                           bool largest,
                           bool sorted,
@@ -1818,7 +1816,7 @@ int32_t ndarray_topk_flat(const struct NdArrayHandle *handle,
  * Returns error if min > max.
  */
 int32_t ndarray_clamp(const struct NdArrayHandle *handle,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       double min_val,
                       double max_val,
                       struct NdArrayHandle **out_handle,
@@ -1829,12 +1827,9 @@ int32_t ndarray_clamp(const struct NdArrayHandle *handle,
 
 /**
  * Concatenate N arrays along the given axis.
- *
- * handles: pointer to array of num_arrays handles
- * metas: pointer to array of num_arrays ViewMetadata pointers
  */
 int32_t ndarray_concatenate(const struct NdArrayHandle *const *handles,
-                            const struct ViewMetadata *const *metas,
+                            const struct ArrayMetadata *const *metas,
                             uintptr_t num_arrays,
                             int32_t axis,
                             struct NdArrayHandle **out_handle,
@@ -1852,7 +1847,7 @@ int32_t ndarray_concatenate(const struct NdArrayHandle *const *handles,
  * Writes to out_offsets (size num_indices+1), out_shapes and out_strides (size (num_indices+1)*ndim each).
  */
 int32_t ndarray_split(const struct NdArrayHandle *_handle,
-                      const struct ViewMetadata *meta,
+                      const struct ArrayMetadata *meta,
                       int32_t axis,
                       const uintptr_t *indices,
                       uintptr_t num_indices,
@@ -1862,12 +1857,9 @@ int32_t ndarray_split(const struct NdArrayHandle *_handle,
 
 /**
  * Stack N arrays along a new axis.
- *
- * handles: pointer to array of num_arrays handles
- * metas: pointer to array of num_arrays ViewMetadata pointers
  */
 int32_t ndarray_stack(const struct NdArrayHandle *const *handles,
-                      const struct ViewMetadata *const *metas,
+                      const struct ArrayMetadata *const *metas,
                       uintptr_t num_arrays,
                       int32_t axis,
                       struct NdArrayHandle **out_handle,
@@ -1879,7 +1871,7 @@ int32_t ndarray_stack(const struct NdArrayHandle *const *handles,
  * Format an array into a string buffer.
  */
 uintptr_t ndarray_to_string(const struct NdArrayHandle *handle,
-                            const struct ViewMetadata *meta,
+                            const struct ArrayMetadata *meta,
                             char *buffer,
                             uintptr_t buffer_size,
                             uintptr_t threshold,

--- a/rust/src/core/macros.rs
+++ b/rust/src/core/macros.rs
@@ -196,9 +196,9 @@ macro_rules! impl_assign_slice {
             $(
                 pub unsafe fn $method(
                     &self,
-                    meta: &$crate::ffi::ViewMetadata,
+                    meta: &$crate::ffi::ArrayMetadata,
                     src: &$crate::core::NDArrayWrapper,
-                    src_meta: &$crate::ffi::ViewMetadata,
+                    src_meta: &$crate::ffi::ArrayMetadata,
                 ) -> Result<(), String> {
                     if let $crate::core::ArrayData::$variant(_) = &self.data {
                     } else {
@@ -309,7 +309,7 @@ macro_rules! impl_copy_view {
             $(
                 pub unsafe fn $method(
                     &self,
-                    meta: &$crate::ffi::ViewMetadata,
+                    meta: &$crate::ffi::ArrayMetadata,
                 ) -> Result<$crate::core::NDArrayWrapper, String> {
                     let shape = meta.shape_slice();
                     let strides = meta.strides_slice();
@@ -361,7 +361,7 @@ macro_rules! impl_fill_slice {
                 pub unsafe fn $method(
                     &self,
                     value: $type,
-                    meta: &$crate::ffi::ViewMetadata,
+                    meta: &$crate::ffi::ArrayMetadata,
                 ) -> Result<(), String> {
                     let shape = meta.shape_slice();
                     let strides = meta.strides_slice();

--- a/rust/src/core/view_helpers.rs
+++ b/rust/src/core/view_helpers.rs
@@ -13,10 +13,10 @@ macro_rules! define_extract_view {
         /// Extract a view of the specific type from the wrapper.
         ///
         /// # Safety
-        /// The caller must ensure the ViewMetadata is valid.
+        /// The caller must ensure the ArrayMetadata is valid.
         pub unsafe fn $name<'a>(
             wrapper: &'a NDArrayWrapper,
-            meta: &'a crate::ffi::ViewMetadata,
+            meta: &'a crate::ffi::ArrayMetadata,
         ) -> Option<ArrayViewD<'a, $type>> {
             let offset = meta.offset;
             let shape = meta.shape_slice();
@@ -54,7 +54,7 @@ macro_rules! define_extract_view_as {
     ($name:ident, $target_type:ty, [$(($source_fn:ident, $conv:expr)),+ $(,)?]) => {
         pub fn $name(
             wrapper: &NDArrayWrapper,
-            meta: &crate::ffi::ViewMetadata,
+            meta: &crate::ffi::ArrayMetadata,
         ) -> Option<ArrayD<$target_type>> {
             unsafe {
                 $(

--- a/rust/src/ffi/arithmetic/add.rs
+++ b/rust/src/ffi/arithmetic/add.rs
@@ -11,16 +11,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Add two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_add(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_add(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_add_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/arithmetic/div.rs
+++ b/rust/src/ffi/arithmetic/div.rs
@@ -11,16 +11,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Divide two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_div(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_div(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_div_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/arithmetic/minmax.rs
+++ b/rust/src/ffi/arithmetic/minmax.rs
@@ -10,7 +10,7 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::minmax_op_arm;
 use crate::ArrayData;
 
@@ -19,9 +19,9 @@ use crate::ArrayData;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_minimum(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -178,9 +178,9 @@ pub unsafe extern "C" fn ndarray_minimum(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_maximum(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/arithmetic/mul.rs
+++ b/rust/src/ffi/arithmetic/mul.rs
@@ -11,16 +11,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Multiply two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_mul(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn ndarray_mul(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_mul_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/arithmetic/rem.rs
+++ b/rust/src/ffi/arithmetic/rem.rs
@@ -13,16 +13,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use crate::scalar_op_arm;
 
 /// Compute the remainder of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_rem(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -128,7 +128,7 @@ pub unsafe extern "C" fn ndarray_rem(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_rem_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/arithmetic/sub.rs
+++ b/rust/src/ffi/arithmetic/sub.rs
@@ -11,16 +11,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Subtract two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sub(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_sub(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sub_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/array/create.rs
+++ b/rust/src/ffi/array/create.rs
@@ -6,7 +6,7 @@ use std::slice;
 use crate::core::NDArrayWrapper;
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 
 /// Create an NDArray from raw data with specified dtype.
 ///
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn ndarray_create(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_copy(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
 ) -> i32 {
     if handle.is_null() || meta.is_null() || out_handle.is_null() {

--- a/rust/src/ffi/array/data.rs
+++ b/rust/src/ffi/array/data.rs
@@ -10,7 +10,7 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{ArrayMetadata, NdArrayHandle};
 use ndarray::ArrayViewD;
 
 /// Get flattened data for an array view with optional offset and length.
@@ -25,7 +25,7 @@ use ndarray::ArrayViewD;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_get_data(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     start: usize,
     len: usize,
     out_data: *mut c_void,

--- a/rust/src/ffi/array/scalar.rs
+++ b/rust/src/ffi/array/scalar.rs
@@ -9,7 +9,7 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{set_last_error, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 
 /// Extract the scalar value from a 0-dimensional array or view.
 ///
@@ -22,7 +22,7 @@ use crate::ffi::{NdArrayHandle, ViewMetadata};
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_as_scalar(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
 ) -> i32 {
     if handle.is_null() || out_value.is_null() || meta.is_null() {

--- a/rust/src/ffi/bitwise/bitand.rs
+++ b/rust/src/ffi/bitwise/bitand.rs
@@ -15,16 +15,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use crate::scalar_op_arm;
 
 /// Compute the bitwise AND of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitand(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_bitand(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitand_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: i64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/bitwise/bitor.rs
+++ b/rust/src/ffi/bitwise/bitor.rs
@@ -15,16 +15,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Compute the bitwise OR of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitor(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_bitor(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitor_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: i64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/bitwise/bitxor.rs
+++ b/rust/src/ffi/bitwise/bitxor.rs
@@ -15,16 +15,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Compute the bitwise XOR of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitxor(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn ndarray_bitxor(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bitxor_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: i64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/bitwise/left_shift.rs
+++ b/rust/src/ffi/bitwise/left_shift.rs
@@ -15,16 +15,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_op_arm;
 
 /// Compute the left shift of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_left_shift(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn ndarray_left_shift(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_left_shift_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: i64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/bitwise/right_shift.rs
+++ b/rust/src/ffi/bitwise/right_shift.rs
@@ -15,16 +15,16 @@ use crate::core::view_helpers::{
 use crate::core::ArrayData;
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use crate::scalar_op_arm;
 
 /// Compute the right shift of two arrays.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_right_shift(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn ndarray_right_shift(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_right_shift_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: i64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/cast.rs
+++ b/rust/src/ffi/cast.rs
@@ -12,7 +12,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_astype(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     target_dtype: i32,
     out: *mut *mut NdArrayHandle,
 ) -> i32 {
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn ndarray_astype(
 }
 
 /// Copy array data when source and target dtypes are the same.
-fn copy_same_dtype(wrapper: &NDArrayWrapper, meta: &ViewMetadata) -> NDArrayWrapper {
+fn copy_same_dtype(wrapper: &NDArrayWrapper, meta: &ArrayMetadata) -> NDArrayWrapper {
     unsafe {
         match &wrapper.data {
             ArrayData::Float64(_) => {
@@ -139,7 +139,7 @@ fn copy_same_dtype(wrapper: &NDArrayWrapper, meta: &ViewMetadata) -> NDArrayWrap
 }
 
 /// Cast array data from source dtype to a desired target dtype.
-fn cast_to_dtype(wrapper: &NDArrayWrapper, meta: &ViewMetadata, target: DType) -> NDArrayWrapper {
+fn cast_to_dtype(wrapper: &NDArrayWrapper, meta: &ArrayMetadata, target: DType) -> NDArrayWrapper {
     match target {
         DType::Float64 => NDArrayWrapper {
             data: ArrayData::Float64(Arc::new(RwLock::new(

--- a/rust/src/ffi/comparison/eq.rs
+++ b/rust/src/ffi/comparison/eq.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise equal comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_eq(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn ndarray_eq(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_eq_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/comparison/gt.rs
+++ b/rust/src/ffi/comparison/gt.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise greater-than comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_gt(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn ndarray_gt(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_gt_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/comparison/gte.rs
+++ b/rust/src/ffi/comparison/gte.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise greater-or-equal comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_gte(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn ndarray_gte(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_gte_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/comparison/lt.rs
+++ b/rust/src/ffi/comparison/lt.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise less-than comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_lt(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn ndarray_lt(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_lt_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/comparison/lte.rs
+++ b/rust/src/ffi/comparison/lte.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise less-or-equal comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_lte(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn ndarray_lte(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_lte_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/comparison/ne.rs
+++ b/rust/src/ffi/comparison/ne.rs
@@ -8,16 +8,16 @@ use crate::core::view_helpers::{
 };
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use crate::scalar_cmp_op_arm;
 
 /// Element-wise not-equal comparison with broadcasting. Returns Bool array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ne(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn ndarray_ne(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ne_scalar(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     scalar: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/indexing/assign.rs
+++ b/rust/src/ffi/indexing/assign.rs
@@ -4,7 +4,7 @@
 
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 
 /// Assign values from source view to destination view.
 ///
@@ -16,9 +16,9 @@ use crate::ffi::{NdArrayHandle, ViewMetadata};
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_assign(
     dst: *const NdArrayHandle,
-    dst_meta: *const ViewMetadata,
+    dst_meta: *const ArrayMetadata,
     src: *const NdArrayHandle,
-    src_meta: *const ViewMetadata,
+    src_meta: *const ArrayMetadata,
 ) -> i32 {
     if dst.is_null() || src.is_null() || dst_meta.is_null() || src_meta.is_null() {
         return ERR_GENERIC;

--- a/rust/src/ffi/indexing/fill.rs
+++ b/rust/src/ffi/indexing/fill.rs
@@ -6,7 +6,7 @@ use std::ffi::c_void;
 
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, SUCCESS};
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{ArrayMetadata, NdArrayHandle};
 
 /// Fill a slice with a value.
 ///
@@ -17,7 +17,7 @@ use crate::ffi::{NdArrayHandle, ViewMetadata};
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_fill(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     value: *const c_void,
 ) -> i32 {
     if handle.is_null() || value.is_null() || meta.is_null() {

--- a/rust/src/ffi/indexing/put.rs
+++ b/rust/src/ffi/indexing/put.rs
@@ -9,7 +9,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, SUCCESS};
 use crate::ffi::indexing::utils::normalize_index;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use ndarray::ArrayD;
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -43,9 +43,9 @@ fn put_impl<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_put(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     values: *const c_void,
     values_len: usize,
     scalar_value: f64,

--- a/rust/src/ffi/indexing/put_along_axis.rs
+++ b/rust/src/ffi/indexing/put_along_axis.rs
@@ -10,7 +10,7 @@ use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, ERR_SHAPE, SUCCESS};
 use crate::ffi::indexing::utils::normalize_index;
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{ArrayMetadata, NdArrayHandle};
 use ndarray::{ArrayD, Dimension, IxDyn};
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -64,9 +64,9 @@ fn put_along_axis_impl<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_put_along_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     axis: i32,
     values: *const c_void,
     values_len: usize,

--- a/rust/src/ffi/indexing/scatter_add.rs
+++ b/rust/src/ffi/indexing/scatter_add.rs
@@ -8,7 +8,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, ERR_MATH, SUCCESS};
 use crate::ffi::indexing::utils::normalize_index;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use ndarray::ArrayD;
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -45,9 +45,9 @@ where
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_scatter_add_flat(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     updates: *const c_void,
     updates_len: usize,
     scalar_update: f64,

--- a/rust/src/ffi/indexing/take.rs
+++ b/rust/src/ffi/indexing/take.rs
@@ -11,7 +11,7 @@ use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, ERR_SHAPE, SUCCESS};
 use crate::ffi::indexing::utils::normalize_index;
 use crate::ffi::output_meta::write_output_metadata;
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, Dimension, IxDyn};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -36,9 +36,9 @@ fn take_impl<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_take(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,
@@ -398,9 +398,9 @@ fn take_axis_impl<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_take_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/indexing/take_along_axis.rs
+++ b/rust/src/ffi/indexing/take_along_axis.rs
@@ -11,7 +11,7 @@ use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, ERR_SHAPE, SUCCESS};
 use crate::ffi::indexing::utils::normalize_index;
 use crate::ffi::output_meta::write_output_metadata;
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, Dimension, IxDyn};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -20,9 +20,9 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_take_along_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     indices_handle: *const NdArrayHandle,
-    indices_meta: *const ViewMetadata,
+    indices_meta: *const ArrayMetadata,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/indexing/where_op.rs
+++ b/rust/src/ffi/indexing/where_op.rs
@@ -8,7 +8,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, ArrayViewD, IxDyn};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -57,11 +57,11 @@ fn where_impl<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_where(
     cond_handle: *const NdArrayHandle,
-    cond_meta: *const ViewMetadata,
+    cond_meta: *const ArrayMetadata,
     x_handle: *const NdArrayHandle,
-    x_meta: *const ViewMetadata,
+    x_meta: *const ArrayMetadata,
     y_handle: *const NdArrayHandle,
-    y_meta: *const ViewMetadata,
+    y_meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/linalg/diagonal.rs
+++ b/rust/src/ffi/linalg/diagonal.rs
@@ -8,7 +8,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_diagonal(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/linalg/dot.rs
+++ b/rust/src/ffi/linalg/dot.rs
@@ -3,7 +3,7 @@
 use crate::core::view_helpers::{extract_view_as_f64, extract_view_f32, extract_view_f64};
 use crate::core::NDArrayWrapper;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 
 /// Compute dot product of two arrays with full view support.
 ///
@@ -11,9 +11,9 @@ use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_dot(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -66,9 +66,9 @@ pub unsafe extern "C" fn ndarray_dot(
 /// Compute dot product using views directly
 fn dot_impl(
     a_wrapper: &NDArrayWrapper,
-    a_meta: &ViewMetadata,
+    a_meta: &ArrayMetadata,
     b_wrapper: &NDArrayWrapper,
-    b_meta: &ViewMetadata,
+    b_meta: &ArrayMetadata,
 ) -> Result<NDArrayWrapper, String> {
     match (a_meta.ndim, b_meta.ndim) {
         (1, 1) => dot_1d_1d(a_wrapper, a_meta, b_wrapper, b_meta),
@@ -85,9 +85,9 @@ fn dot_impl(
 /// 1D @ 1D dot product - iterates directly on views
 fn dot_1d_1d(
     a_wrapper: &NDArrayWrapper,
-    a_meta: &ViewMetadata,
+    a_meta: &ArrayMetadata,
     b_wrapper: &NDArrayWrapper,
-    b_meta: &ViewMetadata,
+    b_meta: &ArrayMetadata,
 ) -> Result<NDArrayWrapper, String> {
     if unsafe { a_meta.shape_slice()[0] } != unsafe { b_meta.shape_slice()[0] } {
         return Err(format!(
@@ -141,9 +141,9 @@ fn dot_1d_1d(
 /// 2D @ 2D matrix multiplication
 fn dot_2d_2d(
     a_wrapper: &NDArrayWrapper,
-    a_meta: &ViewMetadata,
+    a_meta: &ArrayMetadata,
     b_wrapper: &NDArrayWrapper,
-    b_meta: &ViewMetadata,
+    b_meta: &ArrayMetadata,
 ) -> Result<NDArrayWrapper, String> {
     let a_shape = unsafe { a_meta.shape_slice() };
     let b_shape = unsafe { b_meta.shape_slice() };
@@ -212,9 +212,9 @@ fn dot_2d_2d(
 /// 2D @ 1D matrix-vector multiplication
 fn dot_2d_1d(
     a_wrapper: &NDArrayWrapper,
-    a_meta: &ViewMetadata,
+    a_meta: &ArrayMetadata,
     b_wrapper: &NDArrayWrapper,
-    b_meta: &ViewMetadata,
+    b_meta: &ArrayMetadata,
 ) -> Result<NDArrayWrapper, String> {
     let a_shape = unsafe { a_meta.shape_slice() };
     let b_shape = unsafe { b_meta.shape_slice() };
@@ -274,9 +274,9 @@ fn dot_2d_1d(
 /// 1D @ 2D vector-matrix multiplication
 fn dot_1d_2d(
     a_wrapper: &NDArrayWrapper,
-    a_meta: &ViewMetadata,
+    a_meta: &ArrayMetadata,
     b_wrapper: &NDArrayWrapper,
-    b_meta: &ViewMetadata,
+    b_meta: &ArrayMetadata,
 ) -> Result<NDArrayWrapper, String> {
     let a_shape = unsafe { a_meta.shape_slice() };
     let b_shape = unsafe { b_meta.shape_slice() };
@@ -336,7 +336,7 @@ fn dot_1d_2d(
 /// Extract view data as contiguous f64 Vec
 fn extract_as_contiguous_f64(
     wrapper: &NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
 ) -> Result<Vec<f64>, String> {
     unsafe {
         // Try native f64 first

--- a/rust/src/ffi/linalg/matmul.rs
+++ b/rust/src/ffi/linalg/matmul.rs
@@ -1,19 +1,17 @@
-//! Matrix multiplication operation with view support.
+//! Matrix multiplication operation.
 
 use crate::core::view_helpers::{extract_view_as_f64, extract_view_f32, extract_view_f64};
 use crate::core::NDArrayWrapper;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
-/// Matrix multiplication with full view support.
-///
-/// Accepts ViewMetadata for both arrays to properly handle views.
+/// Matrix multiplication.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_matmul(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,
@@ -97,7 +95,7 @@ pub unsafe extern "C" fn ndarray_matmul(
 /// Extract 2D array data from view
 fn extract_2d_data(
     wrapper: &NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
 ) -> Result<(ndarray::Array2<f64>, usize, usize), String> {
     let shape = unsafe { meta.shape_slice() };
     unsafe {

--- a/rust/src/ffi/linalg/norm.rs
+++ b/rust/src/ffi/linalg/norm.rs
@@ -5,7 +5,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, Axis, IxDyn};
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -38,7 +38,7 @@ impl NormOrd {
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_norm(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     ord: i32,
     out_value: *mut c_void,
     out_dtype: *mut u8,
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn ndarray_norm(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_norm_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     ord: i32,
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn ndarray_norm_axis(
     })
 }
 
-fn scalar_norm(wrapper: &NDArrayWrapper, meta: &ViewMetadata, ord: NormOrd) -> Result<f64, String> {
+fn scalar_norm(wrapper: &NDArrayWrapper, meta: &ArrayMetadata, ord: NormOrd) -> Result<f64, String> {
     let view = extract_view_as_f64(wrapper, meta)
         .ok_or_else(|| "Failed to extract view for norm".to_string())?;
     let shape = unsafe { meta.shape_slice() };
@@ -164,7 +164,7 @@ fn scalar_norm(wrapper: &NDArrayWrapper, meta: &ViewMetadata, ord: NormOrd) -> R
 
 fn axis_norm(
     wrapper: &NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     axis: usize,
     keepdims: bool,
     ord: NormOrd,

--- a/rust/src/ffi/linalg/trace.rs
+++ b/rust/src/ffi/linalg/trace.rs
@@ -8,13 +8,13 @@ use crate::core::view_helpers::{
 use crate::core::NDArrayWrapper;
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 /// Compute trace (sum of diagonal elements).
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_trace(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/logical/and.rs
+++ b/rust/src/ffi/logical/and.rs
@@ -5,16 +5,16 @@
 
 use crate::binary_logical_op_arm;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 /// Compute the logical AND of two arrays.
 /// Both arrays are converted to bool first, result is always Bool.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_logical_and(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/logical/not.rs
+++ b/rust/src/ffi/logical/not.rs
@@ -4,7 +4,7 @@
 //! Always returns a Bool array.
 
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use crate::unary_logical_op_arm;
 
 /// Compute the logical NOT of an array.
@@ -12,7 +12,7 @@ use crate::unary_logical_op_arm;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_logical_not(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/logical/or.rs
+++ b/rust/src/ffi/logical/or.rs
@@ -5,16 +5,16 @@
 
 use crate::binary_logical_op_arm;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 /// Compute the logical OR of two arrays.
 /// Both arrays are converted to bool first, result is always Bool.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_logical_or(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/logical/xor.rs
+++ b/rust/src/ffi/logical/xor.rs
@@ -5,16 +5,16 @@
 
 use crate::binary_logical_op_arm;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 
 /// Compute the logical XOR of two arrays.
 /// Both arrays are converted to bool first, result is always Bool.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_logical_xor(
     a: *const NdArrayHandle,
-    a_meta: *const ViewMetadata,
+    a_meta: *const ArrayMetadata,
     b: *const NdArrayHandle,
-    b_meta: *const ViewMetadata,
+    b_meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype_ptr: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/abs.rs
+++ b/rust/src/ffi/math/abs.rs
@@ -7,7 +7,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_abs(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/acos.rs
+++ b/rust/src/ffi/math/acos.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_acos(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/asin.rs
+++ b/rust/src/ffi/math/asin.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_asin(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/atan.rs
+++ b/rust/src/ffi/math/atan.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_atan(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/cbrt.rs
+++ b/rust/src/ffi/math/cbrt.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cbrt(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/ceil.rs
+++ b/rust/src/ffi/math/ceil.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ceil(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/cos.rs
+++ b/rust/src/ffi/math/cos.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cos(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/cosh.rs
+++ b/rust/src/ffi/math/cosh.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cosh(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/exp.rs
+++ b/rust/src/ffi/math/exp.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_exp(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/exp2.rs
+++ b/rust/src/ffi/math/exp2.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_exp2(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/floor.rs
+++ b/rust/src/ffi/math/floor.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_floor(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/hypot.rs
+++ b/rust/src/ffi/math/hypot.rs
@@ -6,7 +6,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_hypot(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     b: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/math/ln.rs
+++ b/rust/src/ffi/math/ln.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ln(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/ln_1p.rs
+++ b/rust/src/ffi/math/ln_1p.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ln_1p(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/log.rs
+++ b/rust/src/ffi/math/log.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_log(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/log10.rs
+++ b/rust/src/ffi/math/log10.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_log10(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/log2.rs
+++ b/rust/src/ffi/math/log2.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_log2(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/neg.rs
+++ b/rust/src/ffi/math/neg.rs
@@ -11,7 +11,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_DTYPE, ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_neg(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/pow2.rs
+++ b/rust/src/ffi/math/pow2.rs
@@ -7,7 +7,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -15,7 +15,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_pow2(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/powf.rs
+++ b/rust/src/ffi/math/powf.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_powf(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     exp: f64,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/math/powi.rs
+++ b/rust/src/ffi/math/powi.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -14,7 +14,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_powi(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     exp: i32,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/math/recip.rs
+++ b/rust/src/ffi/math/recip.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_recip(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/round.rs
+++ b/rust/src/ffi/math/round.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_round(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/sigmoid.rs
+++ b/rust/src/ffi/math/sigmoid.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sigmoid(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/signum.rs
+++ b/rust/src/ffi/math/signum.rs
@@ -7,7 +7,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_signum(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/sin.rs
+++ b/rust/src/ffi/math/sin.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sin(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/sinh.rs
+++ b/rust/src/ffi/math/sinh.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sinh(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/softmax.rs
+++ b/rust/src/ffi/math/softmax.rs
@@ -7,7 +7,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_softmax(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/math/sqrt.rs
+++ b/rust/src/ffi/math/sqrt.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sqrt(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/tan.rs
+++ b/rust/src/ffi/math/tan.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_tan(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/tanh.rs
+++ b/rust/src/ffi/math/tanh.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_tanh(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/to_degrees.rs
+++ b/rust/src/ffi/math/to_degrees.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_to_degrees(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/math/to_radians.rs
+++ b/rust/src/ffi/math/to_radians.rs
@@ -4,7 +4,7 @@ use crate::core::view_helpers::{extract_view_f32, extract_view_f64};
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_to_radians(
     a: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/metadata.rs
+++ b/rust/src/ffi/metadata.rs
@@ -1,12 +1,10 @@
-//! View metadata structure for FFI operations.
-
-use crate::ffi::NdArrayHandle;
+//! Array metadata structure for FFI operations.
 
 /// Metadata describing a view into an array.
 ///
 /// This struct bundles all the metadata needed to describe a view - offset, shape, strides, and ndim.
 #[repr(C)]
-pub struct ViewMetadata {
+pub struct ArrayMetadata {
     /// Offset into the underlying data buffer (in elements, not bytes)
     pub offset: usize,
     /// Pointer to shape dimensions array
@@ -17,8 +15,8 @@ pub struct ViewMetadata {
     pub ndim: usize,
 }
 
-impl ViewMetadata {
-    /// Create ViewMetadata from individual components.
+impl ArrayMetadata {
+    /// Create ArrayMetadata from individual components.
     pub fn new(offset: usize, shape: *const usize, strides: *const usize, ndim: usize) -> Self {
         Self {
             offset,
@@ -42,30 +40,5 @@ impl ViewMetadata {
     /// Caller must ensure strides pointer is valid for ndim elements.
     pub unsafe fn strides_slice(&self) -> &[usize] {
         std::slice::from_raw_parts(self.strides, self.ndim)
-    }
-}
-
-/// Trait for types that can provide ViewMetadata.
-///
-/// This allows uniform access to view metadata from both NdArrayHandle
-/// and ViewMetadata itself.
-pub trait HasViewMetadata {
-    /// Get the view metadata for this object.
-    fn view_metadata(&self) -> ViewMetadata;
-}
-
-impl ViewMetadata {
-    /// Create ViewMetadata from an NdArrayHandle and metadata components.
-    ///
-    /// # Safety
-    /// The shape and strides pointers must be valid for the lifetime of the view operation.
-    pub unsafe fn from_handle(
-        _handle: *const NdArrayHandle,
-        offset: usize,
-        shape: *const usize,
-        strides: *const usize,
-        ndim: usize,
-    ) -> Self {
-        Self::new(offset, shape, strides, ndim)
     }
 }

--- a/rust/src/ffi/mod.rs
+++ b/rust/src/ffi/mod.rs
@@ -22,7 +22,7 @@ pub mod stacking;
 pub mod to_string;
 mod types;
 
-pub use metadata::{HasViewMetadata, ViewMetadata};
+pub use metadata::ArrayMetadata;
 pub use output_meta::write_output_metadata;
 pub use types::NdArrayHandle;
 

--- a/rust/src/ffi/reductions/argmax.rs
+++ b/rust/src/ffi/reductions/argmax.rs
@@ -8,7 +8,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{compute_axis_output_shape, validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, IxDyn};
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argmax_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn ndarray_argmax_axis(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argmax(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {

--- a/rust/src/ffi/reductions/argmin.rs
+++ b/rust/src/ffi/reductions/argmin.rs
@@ -8,7 +8,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{compute_axis_output_shape, validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::{ArrayD, IxDyn};
 use parking_lot::RwLock;
 use std::ffi::c_void;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argmin_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn ndarray_argmin_axis(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argmin(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {

--- a/rust/src/ffi/reductions/bincount.rs
+++ b/rust/src/ffi/reductions/bincount.rs
@@ -7,7 +7,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_DTYPE, ERR_GENERIC, ERR_INDEX, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use ndarray::{ArrayD, IxDyn};
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -47,7 +47,7 @@ where
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_bincount(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     minlength: usize,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/reductions/cumprod.rs
+++ b/rust/src/ffi/reductions/cumprod.rs
@@ -8,7 +8,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cumprod(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn ndarray_cumprod(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cumprod_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/reductions/cumsum.rs
+++ b/rust/src/ffi/reductions/cumsum.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cumsum(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,
@@ -212,7 +212,7 @@ pub unsafe extern "C" fn ndarray_cumsum(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_cumsum_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/reductions/max.rs
+++ b/rust/src/ffi/reductions/max.rs
@@ -11,7 +11,7 @@ use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
 use crate::ffi::reductions::helpers::write_scalar;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_max(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn ndarray_max(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_max_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/reductions/mean.rs
+++ b/rust/src/ffi/reductions/mean.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{compute_axis_output_shape, validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use ndarray::{ArrayD, IxDyn};
 use parking_lot::RwLock;
@@ -22,7 +22,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_mean(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn ndarray_mean(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_mean_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/reductions/min.rs
+++ b/rust/src/ffi/reductions/min.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_min(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn ndarray_min(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_min_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/reductions/product.rs
+++ b/rust/src/ffi/reductions/product.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_product(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn ndarray_product(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_product_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/reductions/std.rs
+++ b/rust/src/ffi/reductions/std.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_std(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     ddof: f64,
     out_value: *mut c_void,
     out_dtype: *mut u8,
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn ndarray_std(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_std_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     ddof: f64,

--- a/rust/src/ffi/reductions/sum.rs
+++ b/rust/src/ffi/reductions/sum.rs
@@ -11,7 +11,7 @@ use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::validate_axis;
 use crate::ffi::reductions::helpers::write_scalar;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sum(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_value: *mut c_void,
     out_dtype: *mut u8,
 ) -> i32 {
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn ndarray_sum(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sum_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/reductions/var.rs
+++ b/rust/src/ffi/reductions/var.rs
@@ -10,7 +10,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::reductions::helpers::{validate_axis, write_scalar};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_var(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     ddof: f64,
     out_value: *mut c_void,
     out_dtype: *mut u8,
@@ -130,7 +130,7 @@ pub unsafe extern "C" fn ndarray_var(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_var_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     keepdims: bool,
     ddof: f64,

--- a/rust/src/ffi/shape_ops/flatten.rs
+++ b/rust/src/ffi/shape_ops/flatten.rs
@@ -9,7 +9,7 @@ use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, SUCCESS};
 use crate::ffi::write_output_metadata;
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use ndarray::Order;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_flatten(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,
@@ -182,7 +182,7 @@ pub unsafe extern "C" fn ndarray_flatten(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_ravel(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     order: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/shape_ops/flip.rs
+++ b/rust/src/ffi/shape_ops/flip.rs
@@ -10,7 +10,7 @@ use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::write_output_metadata;
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use ndarray::Axis;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -23,7 +23,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_flip(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axes: *const i64,
     num_axes: usize,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/shape_ops/pad.rs
+++ b/rust/src/ffi/shape_ops/pad.rs
@@ -11,7 +11,7 @@ use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::shape_ops::helpers::PadMode;
 use crate::ffi::write_output_metadata;
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use ndarray::{ArrayD, ArrayViewD, IxDyn};
 use parking_lot::RwLock;
 use std::slice;
@@ -159,7 +159,7 @@ fn pad_view<T: Copy>(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_pad(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     pad_width: *const usize,
     mode: i32,
     constant_values: *const f64,

--- a/rust/src/ffi/shape_ops/permute.rs
+++ b/rust/src/ffi/shape_ops/permute.rs
@@ -9,7 +9,7 @@ use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::write_output_metadata;
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_permute(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axes: *const usize,
     num_axes: usize,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/shape_ops/repeat.rs
+++ b/rust/src/ffi/shape_ops/repeat.rs
@@ -15,14 +15,14 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{set_last_error, ERR_GENERIC, SUCCESS};
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use crate::ffi::{write_output_metadata, NdArrayHandle};
 
 /// Repeat elements of an array.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_repeat(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     repeats: *const usize,
     repeats_len: usize,
     axis: i32,

--- a/rust/src/ffi/shape_ops/reshape.rs
+++ b/rust/src/ffi/shape_ops/reshape.rs
@@ -8,7 +8,7 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use ndarray::IxDyn;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_reshape(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     new_shape: *const usize,
     new_ndim: usize,
     order: i32,

--- a/rust/src/ffi/shape_ops/tile.rs
+++ b/rust/src/ffi/shape_ops/tile.rs
@@ -15,14 +15,14 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{set_last_error, ERR_GENERIC, SUCCESS};
-use crate::ffi::ViewMetadata;
+use crate::ffi::ArrayMetadata;
 use crate::ffi::{write_output_metadata, NdArrayHandle};
 
 /// Tile an array by repeating it.
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_tile(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     reps: *const usize,
     reps_len: usize,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/shape_ops/transpose.rs
+++ b/rust/src/ffi/shape_ops/transpose.rs
@@ -8,8 +8,8 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, SUCCESS};
 use crate::ffi::write_output_metadata;
+use crate::ffi::ArrayMetadata;
 use crate::ffi::NdArrayHandle;
-use crate::ffi::ViewMetadata;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_transpose(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,
     out_ndim: *mut usize,

--- a/rust/src/ffi/sorting/argsort.rs
+++ b/rust/src/ffi/sorting/argsort.rs
@@ -13,7 +13,7 @@ use crate::ffi::sorting::helpers::{
     argsort_axis_generic, argsort_flat_generic, cmp_f32_asc_nan_last, cmp_f64_asc_nan_last,
     SortKind,
 };
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -21,7 +21,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argsort_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     kind: i32,
     out_handle: *mut *mut NdArrayHandle,
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn ndarray_argsort_axis(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_argsort_flat(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     kind: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/sorting/sort.rs
+++ b/rust/src/ffi/sorting/sort.rs
@@ -12,7 +12,7 @@ use crate::ffi::reductions::helpers::validate_axis;
 use crate::ffi::sorting::helpers::{
     cmp_f32_asc_nan_last, cmp_f64_asc_nan_last, sort_axis_generic, sort_flat_generic, SortKind,
 };
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sort_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     kind: i32,
     out_handle: *mut *mut NdArrayHandle,
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn ndarray_sort_axis(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_sort_flat(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     kind: i32,
     out_handle: *mut *mut NdArrayHandle,
     out_dtype: *mut u8,

--- a/rust/src/ffi/sorting/topk.rs
+++ b/rust/src/ffi/sorting/topk.rs
@@ -12,7 +12,7 @@ use crate::ffi::reductions::helpers::validate_axis;
 use crate::ffi::sorting::helpers::{
     cmp_f32_asc_nan_last, cmp_f64_asc_nan_last, topk_axis_generic, topk_flat_generic, SortKind,
 };
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_topk_axis(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     k: usize,
     largest: bool,
@@ -327,7 +327,7 @@ pub unsafe extern "C" fn ndarray_topk_axis(
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_topk_flat(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     k: usize,
     largest: bool,
     sorted: bool,

--- a/rust/src/ffi/special/clamp.rs
+++ b/rust/src/ffi/special/clamp.rs
@@ -7,7 +7,7 @@ use crate::core::view_helpers::{
 use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{self, ERR_GENERIC, SUCCESS};
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_clamp(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     min_val: f64,
     max_val: f64,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/stacking/concatenate.rs
+++ b/rust/src/ffi/stacking/concatenate.rs
@@ -1,7 +1,6 @@
 //! Concatenate N arrays along an axis.
 //!
-//! Accepts handles and metadata for each array. All arrays must have
-//! same dtype and matching shapes except along axis.
+//! All arrays must have same dtype and matching shapes except along axis.
 
 use ndarray::{concatenate, Axis};
 use parking_lot::RwLock;
@@ -16,16 +15,13 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{set_last_error, ERR_DTYPE, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::stacking::helpers::resolve_axis;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, ArrayMetadata, NdArrayHandle};
 
 /// Concatenate N arrays along the given axis.
-///
-/// handles: pointer to array of num_arrays handles
-/// metas: pointer to array of num_arrays ViewMetadata pointers
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_concatenate(
     handles: *const *const NdArrayHandle,
-    metas: *const *const ViewMetadata,
+    metas: *const *const ArrayMetadata,
     num_arrays: usize,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/stacking/split.rs
+++ b/rust/src/ffi/stacking/split.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{set_last_error, ERR_GENERIC, ERR_INDEX, ERR_SHAPE, SUCCESS};
 use crate::ffi::stacking::helpers::resolve_axis;
-use crate::ffi::{NdArrayHandle, ViewMetadata};
+use crate::ffi::{NdArrayHandle, ArrayMetadata};
 
 /// Split array along axis at the given indices.
 ///
@@ -17,7 +17,7 @@ use crate::ffi::{NdArrayHandle, ViewMetadata};
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_split(
     _handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     axis: i32,
     indices: *const usize,
     num_indices: usize,

--- a/rust/src/ffi/stacking/stack.rs
+++ b/rust/src/ffi/stacking/stack.rs
@@ -1,7 +1,6 @@
 //! Stack N arrays along a new axis.
 //!
-//! Accepts handles and metadata for each array. All arrays must have
-//! same dtype and identical shapes.
+//! All arrays must have same dtype and identical shapes.
 
 use ndarray::{stack, Axis};
 use parking_lot::RwLock;
@@ -16,16 +15,13 @@ use crate::core::{ArrayData, NDArrayWrapper};
 use crate::dtype::DType;
 use crate::error::{set_last_error, ERR_DTYPE, ERR_GENERIC, ERR_SHAPE, SUCCESS};
 use crate::ffi::stacking::helpers::resolve_axis_for_stack;
-use crate::ffi::{write_output_metadata, NdArrayHandle, ViewMetadata};
+use crate::ffi::{write_output_metadata, NdArrayHandle, ArrayMetadata};
 
 /// Stack N arrays along a new axis.
-///
-/// handles: pointer to array of num_arrays handles
-/// metas: pointer to array of num_arrays ViewMetadata pointers
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_stack(
     handles: *const *const NdArrayHandle,
-    metas: *const *const ViewMetadata,
+    metas: *const *const ArrayMetadata,
     num_arrays: usize,
     axis: i32,
     out_handle: *mut *mut NdArrayHandle,

--- a/rust/src/ffi/to_string.rs
+++ b/rust/src/ffi/to_string.rs
@@ -8,7 +8,7 @@ use crate::core::view_helpers::{
     extract_view_as_i32, extract_view_as_i64, extract_view_as_i8, extract_view_as_u16,
     extract_view_as_u32, extract_view_as_u64, extract_view_as_u8,
 };
-use crate::ffi::metadata::ViewMetadata;
+use crate::ffi::metadata::ArrayMetadata;
 use crate::ffi::types::NdArrayHandle;
 use std::io::Write;
 
@@ -16,7 +16,7 @@ use std::io::Write;
 #[no_mangle]
 pub unsafe extern "C" fn ndarray_to_string(
     handle: *const NdArrayHandle,
-    meta: *const ViewMetadata,
+    meta: *const ArrayMetadata,
     buffer: *mut std::os::raw::c_char,
     buffer_size: usize,
     threshold: usize,
@@ -101,7 +101,7 @@ fn write_scalar<T: std::fmt::Display>(
 
 fn format_0d(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     buf: &mut Vec<u8>,
     precision: usize,
 ) -> std::io::Result<()> {
@@ -139,7 +139,7 @@ fn format_0d(
 
 fn format_1d(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     shape: &[usize],
     buf: &mut Vec<u8>,
     threshold: usize,
@@ -163,7 +163,7 @@ fn format_1d(
 
 fn format_1d_elements(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     buf: &mut Vec<u8>,
     start: usize,
     end: usize,
@@ -209,7 +209,7 @@ fn format_1d_elements(
 
 fn format_2d(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     shape: &[usize],
     buf: &mut Vec<u8>,
     threshold: usize,
@@ -250,7 +250,7 @@ fn format_2d(
 
 fn format_2d_row(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     buf: &mut Vec<u8>,
     row: usize,
     cols: usize,
@@ -298,7 +298,7 @@ fn format_2d_row(
 
 fn format_3d(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     shape: &[usize],
     buf: &mut Vec<u8>,
     threshold: usize,
@@ -341,7 +341,7 @@ fn format_3d(
 
 fn format_3d_slice(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     buf: &mut Vec<u8>,
     slice_idx: usize,
     rows: usize,
@@ -361,7 +361,7 @@ fn format_3d_slice(
 
 fn format_3d_row(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     buf: &mut Vec<u8>,
     start_idx: usize,
     cols: usize,
@@ -407,7 +407,7 @@ fn format_3d_row(
 
 fn format_nd(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     shape: &[usize],
     buf: &mut Vec<u8>,
     threshold: usize,
@@ -502,7 +502,7 @@ fn write_indent(buf: &mut Vec<u8>, depth: usize) {
 
 fn format_nd_slice(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     shape: &[usize],
     strides: &[usize],
     offset: usize,
@@ -616,7 +616,7 @@ fn format_nd_slice(
 
 fn format_element_at_offset(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     offset: usize,
     buf: &mut Vec<u8>,
     precision: usize,
@@ -661,7 +661,7 @@ fn format_element_at_offset(
 
 fn format_elements_at_offset(
     wrapper: &crate::core::NDArrayWrapper,
-    meta: &ViewMetadata,
+    meta: &ArrayMetadata,
     stride: usize,
     base_offset: usize,
     start: usize,

--- a/src/ArrayMetadata.php
+++ b/src/ArrayMetadata.php
@@ -8,20 +8,22 @@ use FFI\CData;
 use PhpMlKit\NDArray\FFI\Lib;
 
 /**
- * Holds shape, strides, offset and ndim for an array view.
+ * Holds shape, strides, offset and ndim for an array.
  *
  * NDArray uses this instead of storing those fields directly. When FFI needs
- * a C ViewMetadata struct, call toCData() to build and fill it; use
- * Lib::addr($viewMetadata->toCData()) when passing to FFI.
+ * a C ArrayMetadata struct, call toCData() to build and fill it; use
+ * Lib::addr($metadata->toCData()) when passing to FFI.
  *
  * @internal this is an internal implementation detail, not part of the public API
  */
-final class ViewMetadata
+final class ArrayMetadata
 {
     public readonly int $ndim;
 
     /** @var array<int> */
     public readonly array $strides;
+
+    public readonly int $size;
 
     /** Cached C struct and backing arrays so pointers stay valid. */
     private ?CData $cachedStruct = null;
@@ -42,10 +44,11 @@ final class ViewMetadata
     ) {
         $this->ndim = \count($shape);
         $this->strides = [] !== $strides ? $strides : self::computeStrides($shape);
+        $this->size = (int) array_product($shape);
     }
 
     /**
-     * Build and return the C ViewMetadata struct. Caches the struct and
+     * Build and return the C ArrayMetadata struct. Caches the struct and
      * shape/strides arrays so the returned struct remains valid. Pass
      * Lib::addr($this->toCData()) when an FFI function expects a pointer.
      *
@@ -60,7 +63,7 @@ final class ViewMetadata
         $ffi = Lib::get();
         $this->cachedShapeC = Lib::createShapeArray($this->shape);
         $this->cachedStridesC = Lib::createShapeArray($this->strides);
-        $this->cachedStruct = $ffi->new('struct ViewMetadata', false);
+        $this->cachedStruct = $ffi->new('struct ArrayMetadata', false);
         $this->cachedStruct->offset = $this->offset;
         $this->cachedStruct->shape = \FFI::addr($this->cachedShapeC[0]);
         $this->cachedStruct->strides = \FFI::addr($this->cachedStridesC[0]);

--- a/src/NDArray.php
+++ b/src/NDArray.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray;
 
 use FFI\CData;
-use PhpMlKit\NDArray\Exceptions\NDArrayException;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\Traits\CanBePrinted;
 use PhpMlKit\NDArray\Traits\CreatesArrays;
@@ -49,33 +48,20 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
     use HasSlicing;
     use HasStacking;
 
-    /** View metadata (shape, strides, offset, ndim). */
-    protected readonly ViewMetadata $viewMetadata;
-
-    /** Total number of elements in this array/view */
-    protected int $size;
-
     /**
      * Private constructor — use factory methods.
      *
-     * @param CData      $handle  Opaque pointer to Rust NDArrayWrapper
-     * @param array<int> $shape   Shape of this array/view
-     * @param DType      $dtype   Data type
-     * @param array<int> $strides Element strides per dimension
-     * @param int        $offset  Flat offset into root data
-     * @param null|self  $base    Parent array if this is a view
+     * @param CData         $handle Opaque pointer to Rust NDArrayWrapper
+     * @param ArrayMetadata $meta   View metadata
+     * @param DType         $dtype  Data type
+     * @param null|self     $base   Parent array if this is a view
      */
     protected function __construct(
         protected readonly CData $handle,
-        array $shape,
+        protected readonly ArrayMetadata $meta,
         protected readonly DType $dtype,
-        array $strides = [],
-        int $offset = 0,
         protected readonly ?self $base = null,
-    ) {
-        $this->viewMetadata = new ViewMetadata($shape, $strides, $offset);
-        $this->size = (int) array_product($shape);
-    }
+    ) {}
 
     /**
      * Destructor — only root arrays free Rust memory.
@@ -87,10 +73,6 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
         }
     }
 
-    // =========================================================================
-    // Properties
-    // =========================================================================
-
     /**
      * Get shape.
      *
@@ -98,7 +80,7 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function shape(): array
     {
-        return $this->viewMetadata->shape;
+        return $this->meta->shape;
     }
 
     /**
@@ -108,7 +90,7 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function strides(): array
     {
-        return $this->viewMetadata->strides;
+        return $this->meta->strides;
     }
 
     /**
@@ -116,7 +98,7 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function ndim(): int
     {
-        return $this->viewMetadata->ndim;
+        return $this->meta->ndim;
     }
 
     /**
@@ -124,7 +106,7 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function size(): int
     {
-        return $this->size;
+        return $this->meta->size;
     }
 
     /**
@@ -148,7 +130,7 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function nbytes(): int
     {
-        return $this->size * $this->itemsize();
+        return $this->meta->size * $this->itemsize();
     }
 
     /**
@@ -166,9 +148,9 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      *
      * @internal
      */
-    public function viewMetadata(): ViewMetadata
+    public function meta(): ArrayMetadata
     {
-        return $this->viewMetadata;
+        return $this->meta;
     }
 
     /**
@@ -176,9 +158,9 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      *
      * @internal
      */
-    public function getOffset(): int
+    public function offset(): int
     {
-        return $this->viewMetadata->offset;
+        return $this->meta->offset;
     }
 
     /**
@@ -194,55 +176,9 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
      */
     public function isContiguous(): bool
     {
-        $expected = ViewMetadata::computeStrides($this->viewMetadata->shape);
+        $expected = ArrayMetadata::computeStrides($this->meta->shape);
 
-        return $this->viewMetadata->strides === $expected;
-    }
-
-    /**
-     * Select values from x and y based on a boolean condition.
-     *
-     * @param bool|float|int|self $condition Bool NDArray or scalar condition
-     * @param bool|float|int|self $x         Values where condition is true
-     * @param bool|float|int|self $y         Values where condition is false
-     */
-    public static function where(bool|float|int|self $condition, bool|float|int|self $x, bool|float|int|self $y): self
-    {
-        $condArray = self::coerceWhereOperand($condition, DType::Bool);
-        $xArray = self::coerceWhereOperand($x, null);
-        $yArray = self::coerceWhereOperand($y, null);
-
-        $ffi = Lib::get();
-        $outHandle = $ffi->new('struct NdArrayHandle*');
-        [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
-
-        $condMeta = $condArray->viewMetadata()->toCData();
-        $xMeta = $xArray->viewMetadata()->toCData();
-        $yMeta = $yArray->viewMetadata()->toCData();
-        $status = $ffi->ndarray_where(
-            $condArray->handle,
-            Lib::addr($condMeta),
-            $xArray->handle,
-            Lib::addr($xMeta),
-            $yArray->handle,
-            Lib::addr($yMeta),
-            Lib::addr($outHandle),
-            Lib::addr($outDtypeBuf),
-            Lib::addr($outNdimBuf),
-            $outShapeBuf,
-            Lib::MAX_NDIM
-        );
-
-        Lib::checkStatus($status);
-
-        $dtype = DType::tryFrom((int) $outDtypeBuf->cdata);
-        $ndim = (int) $outNdimBuf->cdata;
-        $shape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
-        if (null === $dtype) {
-            throw new NDArrayException('Invalid dtype returned from Rust for where()');
-        }
-
-        return new self($outHandle, $shape, $dtype);
+        return $this->meta->strides === $expected;
     }
 
     /**
@@ -256,12 +192,10 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
     public function getIterator(): \Generator
     {
         if (1 === $this->ndim()) {
-            // 1D: yield scalars from flat iteration
             foreach ($this->flat() as $value) {
                 yield $value;
             }
         } else {
-            // 2D+: yield views along first axis
             $shape = $this->shape();
             for ($i = 0; $i < $shape[0]; ++$i) {
                 yield $this->slice([$i]);
@@ -282,20 +216,5 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
     public function flat(): FlatIterator
     {
         return new FlatIterator($this);
-    }
-
-    private static function coerceWhereOperand(bool|float|int|self $value, ?DType $forceDtype): self
-    {
-        if ($value instanceof self) {
-            if (null !== $forceDtype && $value->dtype !== $forceDtype) {
-                return $value->astype($forceDtype);
-            }
-
-            return $value;
-        }
-
-        $dtype = $forceDtype ?? DType::fromValue($value);
-
-        return self::array([$value], $dtype);
     }
 }

--- a/src/Traits/CanBePrinted.php
+++ b/src/Traits/CanBePrinted.php
@@ -29,7 +29,7 @@ trait CanBePrinted
         $ffi = Lib::get();
         $buffer = $ffi->new('char[8192]');
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $len = $ffi->ndarray_to_string(
             $this->handle,
             Lib::addr($meta),

--- a/src/Traits/CreatesArrays.php
+++ b/src/Traits/CreatesArrays.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray\Traits;
 
 use FFI\CData;
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\Exceptions\DTypeException;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
@@ -40,7 +41,7 @@ trait CreatesArrays
 
         $handle = self::createTyped($ffi, $dtype, $flatData, $shape, $len);
 
-        return new self($handle, $shape, $dtype);
+        return new self($handle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -64,7 +65,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -88,7 +89,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -148,7 +149,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -186,7 +187,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -249,7 +250,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, [$N, $M], $dtype);
+        return new self($outHandle, new ArrayMetadata([$N, $M]), $dtype);
     }
 
     /**
@@ -298,7 +299,7 @@ trait CreatesArrays
             $num = (int) ceil(($start - $stop) / -$step);
         }
 
-        return new self($outHandle, [$num], $dtype);
+        return new self($outHandle, new ArrayMetadata([$num]), $dtype);
     }
 
     /**
@@ -339,7 +340,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, [$num], $dtype);
+        return new self($outHandle, new ArrayMetadata([$num]), $dtype);
     }
 
     /**
@@ -380,7 +381,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, [$num], $dtype);
+        return new self($outHandle, new ArrayMetadata([$num]), $dtype);
     }
 
     /**
@@ -426,7 +427,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, [$num], $dtype);
+        return new self($outHandle, new ArrayMetadata([$num]), $dtype);
     }
 
     /**
@@ -454,7 +455,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -491,7 +492,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -519,7 +520,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -554,7 +555,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -589,7 +590,7 @@ trait CreatesArrays
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $shape, $dtype);
+        return new self($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**

--- a/src/Traits/HasConversion.php
+++ b/src/Traits/HasConversion.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray\Traits;
 
 use FFI\CData;
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
 use PhpMlKit\NDArray\FFI\Lib;
@@ -28,7 +29,7 @@ trait HasConversion
 
         $ffi = Lib::get();
         $buffer = $ffi->new("uint8_t[{$nbytes}]");
-        $this->intoBuffer($buffer, 0, $this->size);
+        $this->intoBuffer($buffer, 0, $this->size());
 
         return \FFI::string($buffer, $nbytes);
     }
@@ -48,7 +49,7 @@ trait HasConversion
         }
 
         $ffi = Lib::get();
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $out = $this->dtype->createCValue();
 
         $status = $ffi->ndarray_as_scalar(
@@ -75,7 +76,7 @@ trait HasConversion
             return $this->toScalar();
         }
 
-        $flat = $this->getData(0, $this->size);
+        $flat = $this->getData(0, $this->size());
         if (1 === $this->ndim()) {
             return $flat;
         }
@@ -92,7 +93,7 @@ trait HasConversion
     {
         $ffi = Lib::get();
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $outHandle = $ffi->new('struct NdArrayHandle*');
 
         $status = $ffi->ndarray_copy(
@@ -103,7 +104,7 @@ trait HasConversion
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $this->shape(), $this->dtype);
+        return new self($outHandle, new ArrayMetadata($this->shape()), $this->dtype);
     }
 
     /**
@@ -123,7 +124,7 @@ trait HasConversion
         }
 
         $ffi = Lib::get();
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $outHandle = $ffi->new('struct NdArrayHandle*');
 
         $status = $ffi->ndarray_astype(
@@ -135,7 +136,7 @@ trait HasConversion
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $this->shape(), $dtype);
+        return new self($outHandle, new ArrayMetadata($this->shape()), $dtype);
     }
 
     /**
@@ -150,7 +151,7 @@ trait HasConversion
     public function intoBuffer(CData $buffer, int $start = 0, ?int $len = null): int
     {
         if (null === $len) {
-            $len = $this->size - $start;
+            $len = $this->size() - $start;
         }
 
         if (0 === $len || $len < 0) {
@@ -158,7 +159,7 @@ trait HasConversion
         }
 
         $ffi = Lib::get();
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $outLen = $ffi->new('size_t');
 
         $status = $ffi->ndarray_get_data(

--- a/src/Traits/HasIndexing.php
+++ b/src/Traits/HasIndexing.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray\Traits;
 
 use FFI\CData;
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\Exceptions\IndexException;
 use PhpMlKit\NDArray\Exceptions\NDArrayException;
@@ -104,7 +105,7 @@ trait HasIndexing
      */
     public function setAt(int $flatIndex, bool|float|int $value): void
     {
-        $normalized = $this->normalizeIndex($flatIndex, $this->size);
+        $normalized = $this->normalizeIndex($flatIndex, $this->size());
         $storageFlatIndex = $this->logicalFlatToStorageIndex($normalized);
         $this->setElement($storageFlatIndex, $value);
     }
@@ -120,7 +121,7 @@ trait HasIndexing
      */
     public function getAt(int $flatIndex): bool|float|int
     {
-        $normalized = $this->normalizeIndex($flatIndex, $this->size);
+        $normalized = $this->normalizeIndex($flatIndex, $this->size());
         $storageFlatIndex = $this->logicalFlatToStorageIndex($normalized);
 
         return $this->getElement($storageFlatIndex);
@@ -142,8 +143,8 @@ trait HasIndexing
         $outHandle = $ffi->new('struct NdArrayHandle*');
         [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
 
-        $meta = $this->viewMetadata()->toCData();
-        $indicesMeta = $indices->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
+        $indicesMeta = $indices->meta()->toCData();
 
         if (null !== $axis) {
             $status = $ffi->ndarray_take_axis(
@@ -182,7 +183,7 @@ trait HasIndexing
         $ndim = (int) $outNdimBuf->cdata;
         $outShape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
 
-        return new self($outHandle, $outShape, $dtype);
+        return new self($outHandle, new ArrayMetadata($outShape), $dtype);
     }
 
     /**
@@ -198,8 +199,8 @@ trait HasIndexing
         $outHandle = $ffi->new('struct NdArrayHandle*');
         [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
 
-        $meta = $this->viewMetadata()->toCData();
-        $indicesMeta = $indices->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
+        $indicesMeta = $indices->meta()->toCData();
         $status = $ffi->ndarray_take_along_axis(
             $this->handle,
             Lib::addr($meta),
@@ -223,7 +224,7 @@ trait HasIndexing
         $ndim = (int) $outNdimBuf->cdata;
         $outShape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
 
-        return new self($outHandle, $outShape, $dtype);
+        return new self($outHandle, new ArrayMetadata($outShape), $dtype);
     }
 
     /**
@@ -245,8 +246,8 @@ trait HasIndexing
         $ffi = Lib::get();
         $outHandle = $ffi->new('struct NdArrayHandle*');
 
-        $meta = $this->viewMetadata()->toCData();
-        $indicesMeta = $indices->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
+        $indicesMeta = $indices->meta()->toCData();
         $status = $ffi->ndarray_put(
             $this->handle,
             Lib::addr($meta),
@@ -261,7 +262,7 @@ trait HasIndexing
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $this->shape(), $this->dtype);
+        return new self($outHandle, new ArrayMetadata($this->shape()), $this->dtype);
     }
 
     /**
@@ -277,8 +278,8 @@ trait HasIndexing
         $ffi = Lib::get();
         $outHandle = $ffi->new('struct NdArrayHandle*');
 
-        $meta = $this->viewMetadata()->toCData();
-        $indicesMeta = $indices->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
+        $indicesMeta = $indices->meta()->toCData();
         $status = $ffi->ndarray_put_along_axis(
             $this->handle,
             Lib::addr($meta),
@@ -294,7 +295,7 @@ trait HasIndexing
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $this->shape(), $this->dtype);
+        return new self($outHandle, new ArrayMetadata($this->shape()), $this->dtype);
     }
 
     /**
@@ -311,8 +312,8 @@ trait HasIndexing
         $ffi = Lib::get();
         $outHandle = $ffi->new('struct NdArrayHandle*');
 
-        $meta = $this->viewMetadata()->toCData();
-        $indicesMeta = $indices->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
+        $indicesMeta = $indices->meta()->toCData();
         $status = $ffi->ndarray_scatter_add_flat(
             $this->handle,
             Lib::addr($meta),
@@ -327,7 +328,53 @@ trait HasIndexing
 
         Lib::checkStatus($status);
 
-        return new self($outHandle, $this->shape(), $this->dtype);
+        return new self($outHandle, new ArrayMetadata($this->shape()), $this->dtype);
+    }
+
+    /**
+     * Select values from x and y based on a boolean condition.
+     *
+     * @param bool|float|int|NDArray $condition Bool NDArray or scalar condition
+     * @param bool|float|int|NDArray $x         Values where condition is true
+     * @param bool|float|int|NDArray $y         Values where condition is false
+     */
+    public static function where(bool|float|int|NDArray $condition, bool|float|int|NDArray $x, bool|float|int|NDArray $y): NDArray
+    {
+        $condArray = self::coerceWhereOperand($condition, DType::Bool);
+        $xArray = self::coerceWhereOperand($x, null);
+        $yArray = self::coerceWhereOperand($y, null);
+
+        $ffi = Lib::get();
+        $outHandle = $ffi->new('struct NdArrayHandle*');
+        [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
+
+        $condMeta = $condArray->meta()->toCData();
+        $xMeta = $xArray->meta()->toCData();
+        $yMeta = $yArray->meta()->toCData();
+        $status = $ffi->ndarray_where(
+            $condArray->handle,
+            Lib::addr($condMeta),
+            $xArray->handle,
+            Lib::addr($xMeta),
+            $yArray->handle,
+            Lib::addr($yMeta),
+            Lib::addr($outHandle),
+            Lib::addr($outDtypeBuf),
+            Lib::addr($outNdimBuf),
+            $outShapeBuf,
+            Lib::MAX_NDIM
+        );
+
+        Lib::checkStatus($status);
+
+        $dtype = DType::tryFrom((int) $outDtypeBuf->cdata);
+        $ndim = (int) $outNdimBuf->cdata;
+        $shape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
+        if (null === $dtype) {
+            throw new NDArrayException('Invalid dtype returned from Rust for where()');
+        }
+
+        return new NDArray($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -339,7 +386,7 @@ trait HasIndexing
      */
     private function calculateFlatIndex(array $indices): int
     {
-        $flatIndex = $this->getOffset();
+        $flatIndex = $this->offset();
         foreach ($indices as $dim => $index) {
             $flatIndex += $index * $this->strides()[$dim];
         }
@@ -353,10 +400,10 @@ trait HasIndexing
     private function logicalFlatToStorageIndex(int $logicalFlatIndex): int
     {
         if (1 === $this->ndim()) {
-            return $this->getOffset() + ($logicalFlatIndex * $this->strides()[0]);
+            return $this->offset() + ($logicalFlatIndex * $this->strides()[0]);
         }
 
-        $storageIndex = $this->getOffset();
+        $storageIndex = $this->offset();
         $remaining = $logicalFlatIndex;
 
         for ($dim = $this->ndim() - 1; $dim >= 0; --$dim) {
@@ -413,7 +460,7 @@ trait HasIndexing
     {
         $count = \count($indices);
 
-        $newOffset = $this->getOffset();
+        $newOffset = $this->offset();
         foreach ($indices as $dim => $index) {
             $newOffset += $index * $this->strides()[$dim];
         }
@@ -425,10 +472,8 @@ trait HasIndexing
 
         return new self(
             handle: $this->handle,
-            shape: $newShape,
+            meta: new ArrayMetadata($newShape, $newStrides, $newOffset),
             dtype: $this->dtype,
-            strides: $newStrides,
-            offset: $newOffset,
             base: $root,
         );
     }
@@ -452,6 +497,21 @@ trait HasIndexing
         $buffer = $this->dtype->createCArray(\count($flat), $flat);
 
         return [$buffer, \count($flat), 0.0, false];
+    }
+
+    private static function coerceWhereOperand(bool|float|int|NDArray $value, ?DType $forceDtype): NDArray
+    {
+        if ($value instanceof NDArray) {
+            if (null !== $forceDtype && $value->dtype !== $forceDtype) {
+                return $value->astype($forceDtype);
+            }
+
+            return $value;
+        }
+
+        $dtype = $forceDtype ?? DType::fromValue($value);
+
+        return NDArray::array([$value], $dtype);
     }
 
     /**

--- a/src/Traits/HasLinearAlgebra.php
+++ b/src/Traits/HasLinearAlgebra.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMlKit\NDArray\Traits;
 
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\NDArray;
@@ -43,7 +44,7 @@ trait HasLinearAlgebra
             throw new \InvalidArgumentException("Norm order '{$ord}' is only supported when axis is null");
         }
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         if (null === $axis) {
             $outValue = $ffi->new('double');
             $outDtype = $ffi->new('uint8_t');
@@ -74,7 +75,7 @@ trait HasLinearAlgebra
         Lib::checkStatus($status);
         $outShape = $this->computeNormOutputShape($axis, $keepdims);
 
-        return new NDArray($outHandle, $outShape, DType::Float64);
+        return new NDArray($outHandle, new ArrayMetadata($outShape), DType::Float64);
     }
 
     /**

--- a/src/Traits/HasOps.php
+++ b/src/Traits/HasOps.php
@@ -6,6 +6,7 @@ namespace PhpMlKit\NDArray\Traits;
 
 use FFI;
 use FFI\CData;
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\Exceptions\NDArrayException;
 use PhpMlKit\NDArray\FFI\Lib;
@@ -33,7 +34,7 @@ trait HasOps
         $ffi = Lib::get();
         $outHandle = $ffi->new('struct NdArrayHandle*');
         [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
 
         // Normalize extra args: convert BackedEnum to their values
         $normalizedArgs = array_map(
@@ -64,7 +65,7 @@ trait HasOps
         $ndim = (int) $outNdimBuf->cdata;
         $shape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
 
-        return new NDArray($outHandle, $shape, $dtype);
+        return new NDArray($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -84,8 +85,8 @@ trait HasOps
         $outHandle = $ffi->new('struct NdArrayHandle*');
         [$outDtypeBuf, $outNdimBuf, $outShapeBuf] = Lib::createOutputMetadataBuffers();
 
-        $aMeta = $this->viewMetadata()->toCData();
-        $bMeta = $other->viewMetadata()->toCData();
+        $aMeta = $this->meta()->toCData();
+        $bMeta = $other->meta()->toCData();
         $status = $ffi->{$funcName}(
             $this->handle,
             Lib::addr($aMeta),
@@ -108,7 +109,7 @@ trait HasOps
         $ndim = (int) $outNdimBuf->cdata;
         $shape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
 
-        return new NDArray($outHandle, $shape, $dtype);
+        return new NDArray($outHandle, new ArrayMetadata($shape), $dtype);
     }
 
     /**
@@ -126,7 +127,7 @@ trait HasOps
         $outValue = $ffi->new('double');
         $outDtype = $ffi->new('uint8_t');
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $args = [
             $this->handle,
             Lib::addr($meta),

--- a/src/Traits/HasReductions.php
+++ b/src/Traits/HasReductions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMlKit\NDArray\Traits;
 
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\DType;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\NDArray;
@@ -289,7 +290,7 @@ trait HasReductions
         $outValuesHandle = $ffi->new('struct NdArrayHandle*');
         $outIndicesHandle = $ffi->new('struct NdArrayHandle*');
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $outShapeBuf = Lib::createCArray('size_t', array_fill(0, Lib::MAX_NDIM, 0));
 
         $status = $ffi->ndarray_topk_axis(
@@ -312,8 +313,8 @@ trait HasReductions
         $outShape = Lib::extractShapeFromPointer($outShapeBuf, $ndim);
 
         return [
-            'values' => new NDArray($outValuesHandle, $outShape, $this->dtype),
-            'indices' => new NDArray($outIndicesHandle, $outShape, DType::Int64),
+            'values' => new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
+            'indices' => new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
         ];
     }
 
@@ -328,7 +329,7 @@ trait HasReductions
         $outValuesHandle = $ffi->new('struct NdArrayHandle*');
         $outIndicesHandle = $ffi->new('struct NdArrayHandle*');
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $outShapeBuf = Lib::createCArray('size_t', [0]);
 
         $status = $ffi->ndarray_topk_flat(
@@ -348,8 +349,8 @@ trait HasReductions
         $outShape = [(int) $outShapeBuf[0]];
 
         return [
-            'values' => new NDArray($outValuesHandle, $outShape, $this->dtype),
-            'indices' => new NDArray($outIndicesHandle, $outShape, DType::Int64),
+            'values' => new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
+            'indices' => new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
         ];
     }
 }

--- a/src/Traits/HasShapeOps.php
+++ b/src/Traits/HasShapeOps.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PhpMlKit\NDArray\Traits;
 
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\NDArray;
 use PhpMlKit\NDArray\PadMode;
-use PhpMlKit\NDArray\ViewMetadata;
 
 /**
  * Shape manipulation operations.
@@ -75,10 +75,8 @@ trait HasShapeOps
 
             return new self(
                 handle: $this->handle,
-                shape: $newShape,
+                meta: new ArrayMetadata($newShape, [], $this->offset()),
                 dtype: $this->dtype,
-                strides: [],
-                offset: $this->getOffset(),
                 base: $root,
             );
         }
@@ -92,17 +90,15 @@ trait HasShapeOps
                     $stride *= $dimSize;
                 }
             } else {
-                $newStrides = ViewMetadata::computeStrides($newShape);
+                $newStrides = ArrayMetadata::computeStrides($newShape);
             }
 
             $root = $this->base ?? $this;
 
             return new self(
                 handle: $this->handle,
-                shape: $newShape,
+                meta: new ArrayMetadata($newShape, $newStrides, $this->offset()),
                 dtype: $this->dtype,
-                strides: $newStrides,
-                offset: $this->getOffset(),
                 base: $root,
             );
         }
@@ -113,7 +109,7 @@ trait HasShapeOps
         $cShape = Lib::createShapeArray($newShape);
         $orderCode = 'F' === $order ? 1 : 0; // 0=C (RowMajor), 1=F (ColumnMajor)
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $status = $ffi->ndarray_reshape(
             $this->handle,
             Lib::addr($meta),
@@ -125,7 +121,7 @@ trait HasShapeOps
 
         Lib::checkStatus($status);
 
-        return new NDArray($outHandle, $newShape, $this->dtype);
+        return new NDArray($outHandle, new ArrayMetadata($newShape), $this->dtype);
     }
 
     /**
@@ -150,10 +146,8 @@ trait HasShapeOps
 
             return new self(
                 handle: $this->handle,
-                shape: $newShape,
+                meta: new ArrayMetadata($newShape, $newStrides, $this->offset()),
                 dtype: $this->dtype,
-                strides: $newStrides,
-                offset: $this->getOffset(),
                 base: $root,
             );
         }
@@ -212,10 +206,8 @@ trait HasShapeOps
 
         return new self(
             handle: $this->handle,
-            shape: $newShape,
+            meta: new ArrayMetadata($newShape, $newStrides, $this->offset()),
             dtype: $this->dtype,
-            strides: $newStrides,
-            offset: $this->getOffset(),
             base: $root,
         );
     }
@@ -311,10 +303,8 @@ trait HasShapeOps
 
         return new self(
             handle: $this->handle,
-            shape: $newShape,
+            meta: new ArrayMetadata($newShape, $newStrides, $this->offset()),
             dtype: $this->dtype,
-            strides: $newStrides,
-            offset: $this->getOffset(),
             base: $root,
         );
     }
@@ -393,10 +383,8 @@ trait HasShapeOps
 
         return new self(
             handle: $this->handle,
-            shape: $shape,
+            meta: new ArrayMetadata($shape, $strides, $this->offset()),
             dtype: $this->dtype,
-            strides: $strides,
-            offset: $this->getOffset(),
             base: $root,
         );
     }
@@ -428,10 +416,8 @@ trait HasShapeOps
 
             return new self(
                 handle: $this->handle,
-                shape: [$n],
+                meta: new ArrayMetadata([$n], [1], $this->offset()),
                 dtype: $this->dtype,
-                strides: [1],
-                offset: $this->getOffset(),
                 base: $root,
             );
         }
@@ -497,10 +483,8 @@ trait HasShapeOps
 
         return new self(
             handle: $this->handle,
-            shape: $newShape,
+            meta: new ArrayMetadata($newShape, $newStrides, $this->offset()),
             dtype: $this->dtype,
-            strides: $newStrides,
-            offset: $this->getOffset(),
             base: $root,
         );
     }

--- a/src/Traits/HasSlicing.php
+++ b/src/Traits/HasSlicing.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMlKit\NDArray\Traits;
 
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\Exceptions\IndexException;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
 use PhpMlKit\NDArray\FFI\Lib;
@@ -73,7 +74,7 @@ trait HasSlicing
 
         $newShape = [];
         $newStrides = [];
-        $newOffset = $this->getOffset();
+        $newOffset = $this->offset();
 
         foreach ($selection as $dim => $selector) {
             $dimSize = $this->shape()[$dim];
@@ -111,10 +112,8 @@ trait HasSlicing
 
         return new self(
             handle: $this->handle,
-            shape: $newShape,
+            meta: new ArrayMetadata($newShape, $newStrides, $newOffset),
             dtype: $this->dtype,
-            strides: $newStrides,
-            offset: $newOffset,
             base: $root,
         );
     }
@@ -155,7 +154,7 @@ trait HasSlicing
         $ffi = Lib::get();
         $cValue = $this->dtype->createCValue($value);
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $status = $ffi->ndarray_fill($this->handle, Lib::addr($meta), Lib::addr($cValue));
 
         Lib::checkStatus($status);
@@ -168,14 +167,14 @@ trait HasSlicing
      */
     private function assignFromNDArray(NDArray $value): void
     {
-        if ($value->size() !== $this->size) {
+        if ($value->size() !== $this->size()) {
             throw new ShapeException(
-                "Cannot assign array of size {$value->size()} to view of size {$this->size}"
+                "Cannot assign array of size {$value->size()} to view of size {$this->size()}"
             );
         }
 
         $ffi = Lib::get();
-        $dstMeta = $this->viewMetadata()->toCData();
+        $dstMeta = $this->meta()->toCData();
         $src = $value;
         if ($src->shape() !== $this->shape()) {
             if ($src->isContiguous()) {
@@ -184,7 +183,7 @@ trait HasSlicing
                 $src = $src->copy()->reshape($this->shape());
             }
         }
-        $srcMeta = $src->viewMetadata()->toCData();
+        $srcMeta = $src->meta()->toCData();
 
         $status = $ffi->ndarray_assign(
             $this->handle,

--- a/src/Traits/HasStacking.php
+++ b/src/Traits/HasStacking.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpMlKit\NDArray\Traits;
 
+use PhpMlKit\NDArray\ArrayMetadata;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\NDArray;
@@ -46,9 +47,9 @@ trait HasStacking
         }
 
         $ffi = Lib::get();
-        $metaWrappers = array_map(static fn (NDArray $a) => $a->viewMetadata()->toCData(), $arrays);
+        $metaWrappers = array_map(static fn (NDArray $a) => $a->meta()->toCData(), $arrays);
         $cHandles = $ffi->new("struct NdArrayHandle*[{$numArrays}]");
-        $cMetas = $ffi->new("struct ViewMetadata*[{$numArrays}]");
+        $cMetas = $ffi->new("struct ArrayMetadata*[{$numArrays}]");
         for ($i = 0; $i < $numArrays; ++$i) {
             $cHandles[$i] = $arrays[$i]->handle;
             $cMetas[$i] = Lib::addr($metaWrappers[$i]);
@@ -74,7 +75,7 @@ trait HasStacking
         $outNdim = (int) $outNdimBuf->cdata;
         $outShape = Lib::extractShapeFromPointer($outShapeBuf, $outNdim);
 
-        return new self($outHandle, $outShape, $arrays[0]->dtype);
+        return new self($outHandle, new ArrayMetadata($outShape), $arrays[0]->dtype);
     }
 
     /**
@@ -108,9 +109,9 @@ trait HasStacking
         }
 
         $ffi = Lib::get();
-        $metaWrappers = array_map(static fn (NDArray $a) => $a->viewMetadata()->toCData(), $arrays);
+        $metaWrappers = array_map(static fn (NDArray $a) => $a->meta()->toCData(), $arrays);
         $cHandles = $ffi->new("struct NdArrayHandle*[{$numArrays}]");
-        $cMetas = $ffi->new("struct ViewMetadata*[{$numArrays}]");
+        $cMetas = $ffi->new("struct ArrayMetadata*[{$numArrays}]");
         for ($i = 0; $i < $numArrays; ++$i) {
             $cHandles[$i] = $arrays[$i]->handle;
             $cMetas[$i] = Lib::addr($metaWrappers[$i]);
@@ -136,7 +137,7 @@ trait HasStacking
         $outNdim = (int) $outNdimBuf->cdata;
         $outShape = Lib::extractShapeFromPointer($outShapeBuf, $outNdim);
 
-        return new self($outHandle, $outShape, $arrays[0]->dtype);
+        return new self($outHandle, new ArrayMetadata($outShape), $arrays[0]->dtype);
     }
 
     /**
@@ -200,7 +201,7 @@ trait HasStacking
         $cOutShapes = $ffi->new('size_t['.($numParts * $ndim).']');
         $cOutStrides = $ffi->new('size_t['.($numParts * $ndim).']');
 
-        $meta = $this->viewMetadata()->toCData();
+        $meta = $this->meta()->toCData();
         $status = $ffi->ndarray_split(
             $this->handle,
             Lib::addr($meta),
@@ -226,10 +227,8 @@ trait HasStacking
             $partOffset = (int) $cOutOffsets[$i];
             $result[] = new self(
                 $this->handle,
-                $partShape,
+                new ArrayMetadata($partShape, $partStrides, $partOffset),
                 $this->dtype,
-                $partStrides,
-                $partOffset,
                 $base
             );
         }


### PR DESCRIPTION
This PR refactors the NDArray internals by consolidating array metadata handling across both PHP and Rust. It renames `ViewMetadata` to `ArrayMetadata` in both languages, updates the PHP constructor to accept a metadata object instead of individual parameters, and cleans up the Rust FFI metadata module.

## Motivation and Context

The previous implementation had the `NDArray` constructor accepting shape, strides, and offset as separate parameters, then constructing a `ViewMetadata` object internally. This created unnecessary complexity at call sites where each trait had to pass 3-4 parameters to create an array. By accepting an `ArrayMetadata` object directly, we simplify the constructor signature, make the code more maintainable and easier to read, and better separate concerns(callers create the metadata bundle, constructor receives it)
 
The rename from `ViewMetadata` to `ArrayMetadata` is more accurate since all arrays (not just views) carry this metadata. This change is applied consistently across both PHP and Rust to maintain naming parity.

## What's Changed
- Renamed `ViewMetadata` class to `ArrayMetadata` in PHP and Rust
- Simplified `NDArray` constructor to accept `ArrayMetadata` `$meta` parameter
- Updated all PHP traits to construct `ArrayMetadata` objects
- Updated all Rust FFI files to use `ArrayMetadata` instead of `ViewMetadata`
 
## Breaking Changes
None. The `NDArray` constructor is protected and `ViewMetadata`/`ArrayMetadata` are internal implementation details not exposed in the public API.