### PR TITLE
Feat: add global NDArray function proxies and docs

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,16 @@ return (new PhpCsFixer\Config())
         '@PSR12' => true,
         '@PhpCsFixer' => true,
         '@Symfony:risky' => true,
+        'native_function_invocation' => [
+            'include' => [
+                '@compiler_optimized',
+                'abs',
+                'hypot',
+                'ceil'
+            ],
+            'scope' => 'namespaced',
+            'strict' => true,
+        ],
         'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => ['default' => 'single_space'],
         'declare_strict_types' => true,

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,10 @@
   "autoload": {
     "psr-4": {
       "PhpMlKit\\NDArray\\": "src/"
-    }
+    },
+    "files": [
+      "src/Functions.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,7 @@ export default defineConfig({
           text: 'API Reference',
           items: [
             { text: 'Overview', link: '/api/' },
+            { text: 'Global functions', link: '/api/global-functions' },
           ]
         },
         {

--- a/docs/api/global-functions.md
+++ b/docs/api/global-functions.md
@@ -1,0 +1,326 @@
+# Global functions
+
+Complete reference for namespaced functions that proxy to `NDArray` instance methods and static factories. They mirror the behavior documented on the rest of this API reference.
+
+For full parameter lists, edge cases, and examples, follow the links to the corresponding class methods.
+
+---
+
+## Overview
+
+- Each function delegates to `NDArray`; there is no second implementation in PHP.
+- **Binary-style operations** take the receiver array as the **first** argument: `add($a, $b)` is the same as `$a->add($b)`.
+- **Canonical list and signatures** always match the current `src/Functions.php` in the repository.
+
+The catalogue is split into [base](#base), [linear algebra](#linalg), [FFT / DCT](#fft), and [windows](#windows) sections.
+
+---
+
+## Importing
+
+Import only what you need with `use function`:
+
+```php
+<?php
+
+use function PhpMlKit\NDArray\nd_array;
+use function PhpMlKit\NDArray\add;
+use function PhpMlKit\NDArray\Linalg\matmul;
+
+$a = nd_array([[1, 2], [3, 4]]);
+$b = add($a, $a);
+$c = matmul($a, $a);
+```
+
+You can combine imports from the base namespace and sub-namespaces in one `use function` block if you prefer.
+
+---
+
+## Base namespace {#base}
+
+### Array creation and factories
+
+| Function | Maps to | See |
+|----------|---------|-----|
+| `nd_array` | `NDArray::fromArray()` | [Array Creation — fromArray](/api/array-creation#ndarray-fromarray) |
+| `zeros` | `NDArray::zeros()` | [Array Creation — zeros](/api/array-creation#ndarray-zeros) |
+| `ones` | `NDArray::ones()` | [Array Creation — ones](/api/array-creation#ndarray-ones) |
+| `full` | `NDArray::full()` | [Array Creation — full](/api/array-creation#ndarray-full) |
+| `from_buffer` | `NDArray::fromBuffer()` | [Array Creation — fromBuffer](/api/array-creation#ndarray-frombuffer) |
+| `from_bytes` | `NDArray::fromBytes()` | [Array Creation — fromBytes](/api/array-creation#ndarray-frombytes) |
+| `zeros_like` | `NDArray::zerosLike()` | [Array Creation](/api/array-creation) |
+| `ones_like` | `NDArray::onesLike()` | [Array Creation](/api/array-creation) |
+| `full_like` | `NDArray::fullLike()` | [Array Creation](/api/array-creation) |
+| `eye` | `NDArray::eye()` | [Array Creation — eye](/api/array-creation#ndarray-eye) |
+| `arange` | `NDArray::arange()` | [Array Creation — arange](/api/array-creation#ndarray-arange) |
+| `linspace` | `NDArray::linspace()` | [Array Creation — linspace](/api/array-creation#ndarray-linspace) |
+| `logspace` | `NDArray::logspace()` | [Array Creation - logspace](/api/array-creation#ndarray-logspace) |
+| `geomspace` | `NDArray::geomspace()` | [Array Creation - geomspace](/api/array-creation#ndarray-geomspace) |
+| `random` | `NDArray::random()` | [Array Creation - random](/api/array-creation#ndarray-random) |
+| `random_int` | `NDArray::randomInt()` | [Array Creation](/api/array-creation) |
+| `randn` | `NDArray::randn()` | [Array Creation](/api/array-creation) |
+| `normal` | `NDArray::normal()` | [Array Creation - normal](/api/array-creation#ndarray-normal) |
+| `uniform` | `NDArray::uniform()` | [Array Creation - uniform](/api/array-creation#ndarray-uniform) |
+| `tile` | `NDArray::tile()` | [Array Manipulation - tile](/api/array-manipulation#tile) |
+| `repeat` | `NDArray::repeat()` | [Array Manipulation - repeat](/api/array-manipulation#repeat) |
+| `copy` | `$a->copy()` | [Array Manipulation](/api/array-manipulation) |
+| `astype` | `$a->astype()` | [Array Manipulation](/api/array-manipulation) |
+
+### Element-wise math and arithmetic
+
+| Function    | Maps to           | See |
+|-------------|------------------|-----|
+| `add`       | `$a->add()`       | [Mathematical Functions – add](/api/mathematical-functions#add) |
+| `subtract`  | `$a->subtract()`  | [Mathematical Functions – subtract](/api/mathematical-functions#subtract) |
+| `multiply`  | `$a->multiply()`  | [Mathematical Functions – multiply](/api/mathematical-functions#multiply) |
+| `divide`    | `$a->divide()`    | [Mathematical Functions – divide](/api/mathematical-functions#divide) |
+| `rem`       | `$a->rem()`       | [Mathematical Functions – rem](/api/mathematical-functions#rem) |
+| `mod`       | `$a->mod()`       | [Mathematical Functions – mod](/api/mathematical-functions#mod) |
+| `abs`       | `$a->abs()`       | [Mathematical Functions – abs](/api/mathematical-functions#abs) |
+| `negative`  | `$a->negative()`  | [Mathematical Functions – negative](/api/mathematical-functions#negative) |
+| `real`      | `$a->real()`      | [Mathematical Functions – real](/api/mathematical-functions#real) |
+| `imag`      | `$a->imag()`      | [Mathematical Functions – imag](/api/mathematical-functions#imag) |
+| `conjugate` | `$a->conjugate()` | [Mathematical Functions – conjugate](/api/mathematical-functions#conjugate) |
+| `conj`      | `$a->conj()`      | [Mathematical Functions – conj](/api/mathematical-functions#conj) |
+| `iscomplex` | `$a->iscomplex()` | [Mathematical Functions – iscomplex](/api/mathematical-functions#iscomplex) |
+| `isreal`    | `$a->isreal()`    | [Mathematical Functions – isreal](/api/mathematical-functions#isreal) |
+| `angle`     | `$a->angle()`     | [Mathematical Functions – angle](/api/mathematical-functions#angle) |
+| `sqrt`      | `$a->sqrt()`      | [Mathematical Functions – sqrt](/api/mathematical-functions#sqrt) |
+| `exp`       | `$a->exp()`       | [Mathematical Functions – exp](/api/mathematical-functions#exp) |
+| `log`       | `$a->log()`       | [Mathematical Functions – log](/api/mathematical-functions#log) |
+| `ln`        | `$a->ln()`        | [Mathematical Functions – ln](/api/mathematical-functions#ln) |
+| `sin`       | `$a->sin()`       | [Mathematical Functions – sin](/api/mathematical-functions#sin) |
+| `cos`       | `$a->cos()`       | [Mathematical Functions – cos](/api/mathematical-functions#cos) |
+| `tan`       | `$a->tan()`       | [Mathematical Functions – tan](/api/mathematical-functions#tan) |
+| `sinh`      | `$a->sinh()`      | [Mathematical Functions – sinh](/api/mathematical-functions#sinh) |
+| `cosh`      | `$a->cosh()`      | [Mathematical Functions – cosh](/api/mathematical-functions#cosh) |
+| `tanh`      | `$a->tanh()`      | [Mathematical Functions – tanh](/api/mathematical-functions#tanh) |
+| `asin`      | `$a->asin()`      | [Mathematical Functions – asin](/api/mathematical-functions#asin) |
+| `acos`      | `$a->acos()`      | [Mathematical Functions – acos](/api/mathematical-functions#acos) |
+| `atan`      | `$a->atan()`      | [Mathematical Functions – atan](/api/mathematical-functions#atan) |
+| `cbrt`      | `$a->cbrt()`      | [Mathematical Functions – cbrt](/api/mathematical-functions#cbrt) |
+| `ceil`      | `$a->ceil()`      | [Mathematical Functions – ceil](/api/mathematical-functions#ceil) |
+| `exp2`      | `$a->exp2()`      | [Mathematical Functions – exp2](/api/mathematical-functions#exp2) |
+| `floor`     | `$a->floor()`     | [Mathematical Functions – floor](/api/mathematical-functions#floor) |
+| `log2`      | `$a->log2()`      | [Mathematical Functions – log2](/api/mathematical-functions#log2) |
+| `log10`     | `$a->log10()`     | [Mathematical Functions – log10](/api/mathematical-functions#log10) |
+| `pow2`      | `$a->pow2()`      | [Mathematical Functions – pow2](/api/mathematical-functions#pow2) |
+| `round`     | `$a->round()`     | [Mathematical Functions – round](/api/mathematical-functions#round) |
+| `signum`    | `$a->signum()`    | [Mathematical Functions – signum](/api/mathematical-functions#signum) |
+| `recip`     | `$a->recip()`     | [Mathematical Functions – recip](/api/mathematical-functions#recip) |
+| `ln1p`      | `$a->ln1p()`      | [Mathematical Functions – ln1p](/api/mathematical-functions#ln1p) |
+| `to_degrees`| `$a->toDegrees()` | [Mathematical Functions – toDegrees](/api/mathematical-functions#todegrees) |
+| `to_radians`| `$a->toRadians()` | [Mathematical Functions – toRadians](/api/mathematical-functions#toradians) |
+| `powi`      | `$a->powi()`      | [Mathematical Functions – powi](/api/mathematical-functions#powi) |
+| `powf`      | `$a->powf()`      | [Mathematical Functions – powf](/api/mathematical-functions#powf) |
+| `hypot`     | `$a->hypot()`     | [Mathematical Functions – hypot](/api/mathematical-functions#hypot) |
+
+### Bitwise and shifts
+
+| Function      | Maps to             | See                                                              |
+|---------------|--------------------|------------------------------------------------------------------|
+| `bitand`      | `$a->bitand()`     | [Bitwise Operations – bitand](/api/bitwise-operations#bitand)    |
+| `bitor`       | `$a->bitor()`      | [Bitwise Operations – bitor](/api/bitwise-operations#bitor)      |
+| `bitxor`      | `$a->bitxor()`     | [Bitwise Operations – bitxor](/api/bitwise-operations#bitxor)    |
+| `left_shift`  | `$a->leftShift()`  | [Bitwise Operations – left_shift](/api/bitwise-operations#left_shift) |
+| `right_shift` | `$a->rightShift()` | [Bitwise Operations – right_shift](/api/bitwise-operations#right_shift) |
+
+### Clipping and extrema
+
+| Function   | Maps to         | See                                                            |
+|------------|----------------|----------------------------------------------------------------|
+| `clamp`    | `$a->clamp()`  | [Mathematical Functions – clamp](/api/mathematical-functions#clamp)   |
+| `clip`     | `$a->clip()`   | [Mathematical Functions – clip](/api/mathematical-functions#clip)     |
+| `minimum`  | `$a->minimum()`| [Mathematical Functions – minimum](/api/mathematical-functions#minimum) |
+| `maximum`  | `$a->maximum()`| [Mathematical Functions – maximum](/api/mathematical-functions#maximum) |
+| `sigmoid`  | `$a->sigmoid()`| [Mathematical Functions – sigmoid](/api/mathematical-functions#sigmoid) |
+| `softmax`  | `$a->softmax()`| [Mathematical Functions – softmax](/api/mathematical-functions#softmax) |
+
+### Comparisons
+
+| Function | Maps to       | See                                                        |
+|----------|--------------|------------------------------------------------------------|
+| `eq`     | `$a->eq()`   | [Logic Functions – eq](/api/logic-functions#eq)            |
+| `ne`     | `$a->ne()`   | [Logic Functions – ne](/api/logic-functions#ne)            |
+| `gt`     | `$a->gt()`   | [Logic Functions – gt](/api/logic-functions#gt)            |
+| `gte`    | `$a->gte()`  | [Logic Functions – gte](/api/logic-functions#gte)          |
+| `lt`     | `$a->lt()`   | [Logic Functions – lt](/api/logic-functions#lt)            |
+| `lte`    | `$a->lte()`  | [Logic Functions – lte](/api/logic-functions#lte)          |
+
+### Logical (boolean element-wise)
+
+| Function | Maps to       | See                                                    |
+|----------|--------------|--------------------------------------------------------|
+| `and`    | `$a->and()`  | [Logic Functions – and](/api/logic-functions#and)      |
+| `or`     | `$a->or()`   | [Logic Functions – or](/api/logic-functions#or)        |
+| `not`    | `$a->not()`  | [Logic Functions – not](/api/logic-functions#not)      |
+| `xor`    | `$a->xor()`  | [Logic Functions – xor](/api/logic-functions#xor)      |
+
+### Statistics and reductions
+
+| Function    | Maps to           | See                                                      |
+|-------------|------------------|----------------------------------------------------------|
+| `sum`       | `$a->sum()`      | [Statistics – sum](/api/statistics#sum)                  |
+| `mean`      | `$a->mean()`     | [Statistics – mean](/api/statistics#mean)                |
+| `amin`      | `$a->min()`      | [Statistics – min](/api/statistics#min)                  |
+| `amax`      | `$a->max()`      | [Statistics – max](/api/statistics#max)                  |
+| `argmin`    | `$a->argmin()`   | [Sorting & Searching – argmin](/api/sorting-searching#argmin) |
+| `argmax`    | `$a->argmax()`   | [Sorting & Searching – argmax](/api/sorting-searching#argmax) |
+| `sort`      | `$a->sort()`     | [Sorting & Searching – sort](/api/sorting-searching#sort)     |
+| `argsort`   | `$a->argsort()`  | [Sorting & Searching – argsort](/api/sorting-searching#argsort) |
+| `topk`      | `$a->topk()`     | [Sorting & Searching – topk](/api/sorting-searching#topk)     |
+| `product`   | `$a->product()`  | [Statistics – product](/api/statistics#product)          |
+| `cumsum`    | `$a->cumsum()`   | [Statistics – cumsum](/api/statistics#cumsum)            |
+| `cumprod`   | `$a->cumprod()`  | [Statistics – cumprod](/api/statistics#cumprod)          |
+| `var`       | `$a->var()`      | [Statistics – var](/api/statistics#var)                  |
+| `std`       | `$a->std()`      | [Statistics – std](/api/statistics#std)                  |
+| `bincount`  | `$a->bincount()` | [Statistics – bincount](/api/statistics#bincount)        |
+
+### Shape, padding, tiling
+
+| Function       | Maps to            | See                                                                          |
+|----------------|-------------------|------------------------------------------------------------------------------|
+| `pad`          | `$a->pad()`        | [Array Manipulation – pad](/api/array-manipulation#pad)                      |
+| `reshape`      | `$a->reshape()`    | [Array Manipulation – reshape](/api/array-manipulation#reshape)              |
+| `transpose`    | `$a->transpose()`  | [Array Manipulation – transpose](/api/array-manipulation#transpose)          |
+| `swapaxes`     | `$a->swapaxes()`   | [Array Manipulation – swapaxes](/api/array-manipulation#swapaxes)            |
+| `permute`      | `$a->permute()`    | [Array Manipulation – permute](/api/array-manipulation#permute)              |
+| `mergeaxes`    | `$a->mergeaxes()`  | [Array Manipulation – mergeaxes](/api/array-manipulation#mergeaxes)          |
+| `flip`         | `$a->flip()`       | [Array Manipulation – flip](/api/array-manipulation#flip)                    |
+| `insertaxis`   | `$a->insertaxis()` | [Array Manipulation – insertaxis](/api/array-manipulation#insertaxis)        |
+| `flatten`      | `$a->flatten()`    | [Array Manipulation – flatten](/api/array-manipulation#flatten)              |
+| `ravel`        | `$a->ravel()`      | [Array Manipulation – ravel](/api/array-manipulation#ravel)                  |
+| `squeeze`      | `$a->squeeze()`    | [Array Manipulation – squeeze](/api/array-manipulation#squeeze)              |
+| `expand_dims`  | `$a->expandDims()` | [Array Manipulation – expandDims](/api/array-manipulation#expanddims)        |
+| `tile`         | `$a->tile()`       | [Array Manipulation – tile](/api/array-manipulation#tile)                    |
+| `repeat`       | `$a->repeat()`     | [Array Manipulation – repeat](/api/array-manipulation#repeat)                |
+
+### Stacking and splitting
+
+| Function        | Maps to                   | See                                                              |
+|-----------------|--------------------------|------------------------------------------------------------------|
+| `concatenate`   | `NDArray::concatenate()`  | [Array Manipulation – concatenate](/api/array-manipulation#concatenate) |
+| `stack`         | `NDArray::stack()`        | [Array Manipulation – stack](/api/array-manipulation#stack)             |
+| `vstack`        | `NDArray::vstack()`       | [Array Manipulation – vstack](/api/array-manipulation#vstack)           |
+| `hstack`        | `NDArray::hstack()`       | [Array Manipulation – hstack](/api/array-manipulation#hstack)           |
+| `split`         | `$a->split()`             | [Array Manipulation – split](/api/array-manipulation#split)              |
+| `vsplit`        | `$a->vsplit()`            | [Array Manipulation – vsplit](/api/array-manipulation#vsplit)            |
+| `hsplit`        | `$a->hsplit()`            | [Array Manipulation – hsplit](/api/array-manipulation#hsplit)            |
+
+### Indexing, take/put, selection
+
+| Function           | Maps to                | See                                                         |
+|--------------------|-----------------------|-------------------------------------------------------------|
+| `get`              | `$a->get()`           | [Indexing Routines – get](/api/indexing-routines#get)                       |
+| `set`              | `$a->set()`           | [Indexing Routines – set](/api/indexing-routines#set)                       |
+| `set_at`           | `$a->setAt()`         | [Indexing Routines – setAt](/api/indexing-routines#setat)                   |
+| `get_at`           | `$a->getAt()`         | [Indexing Routines – getAt](/api/indexing-routines#getat)                   |
+| `take`             | `$a->take()`          | [Indexing Routines – take](/api/indexing-routines#take)                     |
+| `take_along_axis`  | `$a->takeAlongAxis()` | [Indexing Routines – takeAlongAxis](/api/indexing-routines#takealongaxis)   |
+| `put`              | `$a->put()`           | [Indexing Routines – put](/api/indexing-routines#put)                       |
+| `put_along_axis`   | `$a->putAlongAxis()`  | [Indexing Routines – putAlongAxis](/api/indexing-routines#putalongaxis)     |
+| `scatter_add`      | `$a->scatterAdd()`    | [Indexing Routines – scatterAdd](/api/indexing-routines#scatteradd)         |
+| `where`            | `NDArray::where()`    | [Indexing Routines – where](/api/indexing-routines#where)                   |
+
+### Slicing and assignment
+
+| Function   | Maps to         | See                                                   |
+|------------|----------------|-------------------------------------------------------|
+| `slice`    | `$a->slice()`  | [Indexing Routines – slice](/api/indexing-routines#slice)       |
+| `assign`   | `$a->assign()` | [Indexing Routines – assign](/api/indexing-routines#assign)     |
+
+---
+
+## Linear algebra namespace {#linalg}
+
+Import with:
+
+```php
+use function PhpMlKit\NDArray\Linalg\norm;
+use function PhpMlKit\NDArray\Linalg\matmul;
+```
+
+| Function         | Maps to                | See                                                        |
+|------------------|-----------------------|------------------------------------------------------------|
+| `norm`           | `$a->norm()`           | [Linear Algebra – norm](/api/linear-algebra#norm)          |
+| `dot`            | `$a->dot()`            | [Linear Algebra – dot](/api/linear-algebra#dot)            |
+| `matmul`         | `$a->matmul()`         | [Linear Algebra – matmul](/api/linear-algebra#matmul)      |
+| `diagonal`       | `$a->diagonal()`       | [Linear Algebra – diagonal](/api/linear-algebra#diagonal)  |
+| `diag`           | `$a->diag()`           | [Linear Algebra – diag](/api/linear-algebra#diag)          |
+| `trace`          | `$a->trace()`          | [Linear Algebra – trace](/api/linear-algebra#trace)        |
+| `solve`          | `$a->solve()`          | [Linear Algebra – solve](/api/linear-algebra#solve)        |
+| `inv`            | `$a->inv()`            | [Linear Algebra – inv](/api/linear-algebra#inv)            |
+| `det`            | `$a->det()`            | [Linear Algebra – det](/api/linear-algebra#det)            |
+| `svd`            | `$a->svd()`            | [Linear Algebra – svd](/api/linear-algebra#svd)            |
+| `qr`             | `$a->qr()`             | [Linear Algebra – qr](/api/linear-algebra#qr)              |
+| `eig`            | `$a->eig()`            | [Linear Algebra – eig](/api/linear-algebra#eig)            |
+| `eigvals`        | `$a->eigvals()`        | [Linear Algebra – eigvals](/api/linear-algebra#eigvals)    |
+| `eigh`           | `$a->eigh()`           | [Linear Algebra – eigh](/api/linear-algebra#eigh)          |
+| `eigvalsh`       | `$a->eigvalsh()`       | [Linear Algebra – eigvalsh](/api/linear-algebra#eigvalsh)  |
+| `cholesky`       | `$a->cholesky()`       | [Linear Algebra – cholesky](/api/linear-algebra#cholesky)  |
+| `lstsq`          | `$a->lstsq()`          | [Linear Algebra – lstsq](/api/linear-algebra#lstsq)        |
+| `least_squares`  | `$a->leastSquares()`   | [Linear Algebra – leastSquares](/api/linear-algebra#leastsquares) |
+| `pinv`           | `$a->pinv()`           | [Linear Algebra – pinv](/api/linear-algebra#pinv)          |
+| `cond`           | `$a->cond()`           | [Linear Algebra – cond](/api/linear-algebra#cond)          |
+| `rank`           | `$a->rank()`           | [Linear Algebra – rank](/api/linear-algebra#rank)          |
+
+---
+
+## FFT and DCT namespace {#fft}
+
+Import with:
+
+```php
+use function PhpMlKit\NDArray\Fft\fft;
+use function PhpMlKit\NDArray\Fft\ifft;
+```
+
+| Function | Maps to        | See                                         |
+|----------|---------------|----------------------------------------------|
+| `fft`    | `$a->fft()`    | [Signal Processing – fft](/api/signal-processing#fft)       |
+| `ifft`   | `$a->ifft()`   | [Signal Processing – ifft](/api/signal-processing#ifft)     |
+| `fftn`   | `$a->fftn()`   | [Signal Processing – fftn](/api/signal-processing#fftn)     |
+| `ifftn`  | `$a->ifftn()`  | [Signal Processing – ifftn](/api/signal-processing#ifftn)   |
+| `rfft`   | `$a->rfft()`   | [Signal Processing – rfft](/api/signal-processing#rfft)     |
+| `irfft`  | `$a->irfft()`  | [Signal Processing – irfft](/api/signal-processing#irfft)   |
+| `fft2`   | `$a->fft2()`   | [Signal Processing – fft2](/api/signal-processing#fft2)     |
+| `ifft2`  | `$a->ifft2()`  | [Signal Processing – ifft2](/api/signal-processing#ifft2)   |
+| `dct`    | `$a->dct()`    | [Signal Processing – dct](/api/signal-processing#dct)       |
+| `idct`   | `$a->idct()`   | [Signal Processing – idct](/api/signal-processing#idct)     |
+| `dctn`   | `$a->dctn()`   | [Signal Processing – dctn](/api/signal-processing#dctn)     |
+| `idctn`  | `$a->idctn()`  | [Signal Processing – idctn](/api/signal-processing#idctn)   |
+| `dct2`   | `$a->dct2()`   | [Signal Processing – dct2](/api/signal-processing#dct2)     |
+| `idct2`  | `$a->idct2()`  | [Signal Processing – idct2](/api/signal-processing#idct2)   |
+
+---
+
+## Window functions namespace {#windows}
+
+Import with:
+
+```php
+use function PhpMlKit\NDArray\Windows\hanning;
+```
+
+Each function wraps the matching static method on `NDArray` and returns a `Float64` vector of length `$m`.
+
+| Function   | Maps to                | See                                                 |
+|------------|-----------------------|-----------------------------------------------------|
+| `bartlett` | `NDArray::bartlett()` | [Window Functions – bartlett](/api/window-functions#bartlett) |
+| `blackman` | `NDArray::blackman()` | [Window Functions – blackman](/api/window-functions#blackman) |
+| `bohman`   | `NDArray::bohman()`   | [Window Functions – bohman](/api/window-functions#bohman)     |
+| `boxcar`   | `NDArray::boxcar()`   | [Window Functions – boxcar](/api/window-functions#boxcar)     |
+| `hamming`  | `NDArray::hamming()`  | [Window Functions – hamming](/api/window-functions#hamming)   |
+| `hanning`  | `NDArray::hanning()`  | [Window Functions – hanning](/api/window-functions#hanning)   |
+| `hann`     | `NDArray::hann()`     | [Window Functions – hann](/api/window-functions#hann)         |
+| `kaiser`   | `NDArray::kaiser()`   | [Window Functions – kaiser](/api/window-functions#kaiser)     |
+| `lanczos`  | `NDArray::lanczos()`  | [Window Functions – lanczos](/api/window-functions#lanczos)   |
+| `triang`   | `NDArray::triang()`   | [Window Functions – triang](/api/window-functions#triang)     |
+
+---
+
+## See also
+
+- [API Reference overview](/api/)
+- [NDArray class](/api/ndarray-class)
+- Source: `src/Functions.php` in the package repository

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -24,6 +24,11 @@ Complete reference for all NDArray classes and methods.
 - [Signal Processing](/api/signal-processing) - FFT, real FFT, and DCT
 - [Window Functions](/api/window-functions) - Hann, Hamming, Blackman, Kaiser, and more
 
+
+## Global functions
+
+- **[Global functions](/api/global-functions)** — Full list, import examples, and links back to each topic page.
+
 ## Other
 
 - [Exceptions](/api/exceptions) - Error handling
@@ -50,6 +55,11 @@ Complete reference for all NDArray classes and methods.
 **Shape:**
 - `reshape()`, `transpose()`, `flatten()`
 - `slice()` - Extract subarrays
+
+
+### Global functions
+
+Most operations from the method reference are also available as functions under `PhpMlKit\NDArray` (and in the `Linalg`, `Fft`, and `Windows` sub-namespaces). See the [exhaustive global functions page](/api/global-functions).
 
 ## Next Steps
 

--- a/docs/api/linear-algebra.md
+++ b/docs/api/linear-algebra.md
@@ -2,6 +2,10 @@
 
 Reference for linear algebra operations.
 
+::: tip Global functions
+Each routine on this page is also available as a function under `PhpMlKit\NDArray\Linalg` (for example, `norm($a, …)` calls `$a->norm(…)`). See [Global functions — Linear algebra](/api/global-functions#linalg).
+:::
+
 ## norm()
 
 ```php

--- a/docs/api/signal-processing.md
+++ b/docs/api/signal-processing.md
@@ -4,6 +4,10 @@ Discrete transforms for frequency-domain analysis (FFT, real FFT, and DCT).
 
 All methods on this page are instance methods on `NDArray`.
 
+::: tip Global functions
+FFT and DCT entry points are also exposed as functions under `PhpMlKit\NDArray\Fft` (for example, `fft($a, …)` calls `$a->fft(…)`). See [Global functions — FFT and DCT](/api/global-functions#fft).
+:::
+
 ::: tip Normalization
 Transforms accept a `Normalization` enum (`backward`, `ortho`, `forward`, `none`). Default: `Normalization::Backward`.
 :::

--- a/docs/api/window-functions.md
+++ b/docs/api/window-functions.md
@@ -4,6 +4,10 @@ Reference for common window functions used in signal processing (tapering) befor
 
 All functions on this page are **static methods** on `NDArray` and return a `Float64` array of shape `[m]`.
 
+::: tip Global functions
+These windows are also available as functions under `PhpMlKit\NDArray\Windows` (for example, `hanning($m)` calls `NDArray::hanning($m)`). See [Global functions — Window functions](/api/global-functions#windows).
+:::
+
 ::: tip Symmetric vs periodic
 All window functions accept a `$periodic` flag:
 

--- a/docs/guide/fundamentals/operations.md
+++ b/docs/guide/fundamentals/operations.md
@@ -4,6 +4,8 @@ Overview of the operations available on NDArrays.
 
 NDArray provides a comprehensive set of operations for numerical computing. This page provides a conceptual overview—see the [API Reference](/api/) for complete method details.
 
+The same operations are also published as **namespaced functions** under `PhpMlKit\NDArray` (with linear algebra, FFT/DCT, and window helpers in dedicated sub-namespaces). See [Global functions](/api/global-functions) for the full list of available global functions.
+
 ## Operation Categories
 
 ### 1. Arithmetic Operations

--- a/src/Complex.php
+++ b/src/Complex.php
@@ -57,7 +57,7 @@ final class Complex
      */
     public function magnitude(): float
     {
-        return hypot($this->real, $this->imag);
+        return \hypot($this->real, $this->imag);
     }
 
     /**
@@ -73,7 +73,7 @@ final class Complex
      */
     public function equals(self $other, float $tol = 1e-10): bool
     {
-        return abs($this->real - $other->real) <= $tol
-            && abs($this->imag - $other->imag) <= $tol;
+        return \abs($this->real - $other->real) <= $tol
+            && \abs($this->imag - $other->imag) <= $tol;
     }
 }

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -1,0 +1,2109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMlKit\NDArray {
+    use FFI\CData;
+    use PhpMlKit\NDArray\Exceptions\ShapeException;
+
+    /**
+     * Functional proxies for {@see NDArray} instance and static APIs, grouped by trait.
+     */
+
+    // =============================================================================
+    // CreatesArrays — factories, buffers, random, sequences, copy / astype
+    // =============================================================================
+
+    /**
+     * Create array from PHP array.
+     *
+     * @param array<mixed>    $data  Nested PHP array
+     * @param null|array<int> $shape Optional shape. If null, inferred from data.
+     * @param null|DType      $dtype Data type (auto-inferred if null)
+     */
+    function nd_array(array $data, ?array $shape = null, ?DType $dtype = null): NDArray
+    {
+        return NDArray::fromArray($data, $shape, $dtype);
+    }
+
+    /**
+     * Create an array filled with zeros.
+     *
+     * @param array<int> $shape Array shape
+     * @param DType      $dtype Data type (default: Float64)
+     */
+    function zeros(array $shape, DType $dtype = DType::Float64): NDArray
+    {
+        return NDArray::zeros($shape, $dtype);
+    }
+
+    /**
+     * Create an array filled with ones.
+     *
+     * @param array<int> $shape Array shape
+     * @param DType      $dtype Data type (default: Float64)
+     */
+    function ones(array $shape, DType $dtype = DType::Float64): NDArray
+    {
+        return NDArray::ones($shape, $dtype);
+    }
+
+    /**
+     * Create an array filled with a specific value.
+     *
+     * @param bool|Complex|float|int $value Value to fill array with
+     * @param array<int>             $shape Array shape
+     * @param null|DType             $dtype Data type (default: inferred from value)
+     */
+    function full(bool|Complex|float|int $value, array $shape, ?DType $dtype = null): NDArray
+    {
+        return NDArray::full($value, $shape, $dtype);
+    }
+
+    /**
+     * Create an array from an external C buffer pointer.
+     *
+     * This method copies data from an external FFI buffer into a new NDArray. The source buffer
+     * remains owned by the caller - this method creates an independent copy.
+     *
+     * @param CData      $buffer Pointer to raw C data (e.g., float*, int16_t*)
+     * @param array<int> $shape  Array shape
+     * @param DType      $dtype  Data type of the buffer
+     *
+     * @throws ShapeException If buffer size doesn't match shape
+     */
+    function from_buffer(CData $buffer, array $shape, DType $dtype): NDArray
+    {
+        return NDArray::fromBuffer($buffer, $shape, $dtype);
+    }
+
+    /**
+     * Create an array from a binary string.
+     *
+     * This method interprets a PHP binary string as raw array data in little-endian format.
+     * The bytes are copied into a new NDArray with the specified shape and dtype.
+     *
+     * @param string     $bytes Binary string containing raw array data (little-endian)
+     * @param array<int> $shape Array shape
+     * @param DType      $dtype Data type of the buffer
+     *
+     * @throws ShapeException If buffer size doesn't match shape
+     */
+    function from_bytes(string $bytes, array $shape, DType $dtype): NDArray
+    {
+        return NDArray::fromBytes($bytes, $shape, $dtype);
+    }
+
+    /**
+     * Create an array of zeros with the same shape as the input array.
+     *
+     * @param NDArray    $array Input array defining the output shape
+     * @param null|DType $dtype Data type (default: same as input array)
+     */
+    function zeros_like(NDArray $array, ?DType $dtype = null): NDArray
+    {
+        return NDArray::zerosLike($array, $dtype);
+    }
+
+    /**
+     * Create an array of ones with the same shape as the input array.
+     *
+     * @param NDArray    $array Input array defining the output shape
+     * @param null|DType $dtype Data type (default: same as input array)
+     */
+    function ones_like(NDArray $array, ?DType $dtype = null): NDArray
+    {
+        return NDArray::onesLike($array, $dtype);
+    }
+
+    /**
+     * Create an array filled with a specific value, with the same shape as the input array.
+     *
+     * @param NDArray                $array Input array defining the output shape
+     * @param bool|Complex|float|int $value Value to fill array with
+     * @param null|DType             $dtype Data type (default: inferred from value or same as input)
+     */
+    function full_like(NDArray $array, bool|Complex|float|int $value, ?DType $dtype = null): NDArray
+    {
+        return NDArray::fullLike($array, $value, $dtype);
+    }
+
+    /**
+     * Create a 2D identity matrix.
+     *
+     * @param int      $N     Number of rows
+     * @param null|int $M     Number of columns (default: N)
+     * @param int      $k     Diagonal index (0: main, >0: upper, <0: lower)
+     * @param DType    $dtype Data type (default: Float64)
+     */
+    function eye(int $N, ?int $M = null, int $k = 0, DType $dtype = DType::Float64): NDArray
+    {
+        return NDArray::eye($N, $M, $k, $dtype);
+    }
+
+    /**
+     * Create evenly spaced values within a given interval.
+     *
+     * @param float|int      $start Start of interval (inclusive)
+     * @param null|float|int $stop  End of interval (exclusive)
+     * @param float|int      $step  Spacing between values
+     * @param null|DType     $dtype Data type
+     */
+    function arange(float|int $start, float|int|null $stop = null, float|int $step = 1, ?DType $dtype = null): NDArray
+    {
+        return NDArray::arange($start, $stop, $step, $dtype);
+    }
+
+    /**
+     * Create evenly spaced numbers over a specified interval.
+     *
+     * @param float $start    The starting value of the sequence
+     * @param float $stop     The end value of the sequence
+     * @param int   $num      Number of samples to generate
+     * @param bool  $endpoint If true, stop is the last sample
+     * @param DType $dtype    Data type (default: Float64)
+     */
+    function linspace(
+        float $start,
+        float $stop,
+        int $num = 50,
+        bool $endpoint = true,
+        DType $dtype = DType::Float64,
+    ): NDArray {
+        return NDArray::linspace($start, $stop, $num, $endpoint, $dtype);
+    }
+
+    /**
+     * Create numbers spaced evenly on a log scale.
+     *
+     * @param float $start The starting exponent (base**start is the first value)
+     * @param float $stop  The end exponent (base**stop is the final value)
+     * @param int   $num   Number of samples to generate
+     * @param float $base  The base of the log space
+     * @param DType $dtype Data type (default: Float64)
+     */
+    function logspace(
+        float $start,
+        float $stop,
+        int $num = 50,
+        float $base = 10.0,
+        DType $dtype = DType::Float64,
+    ): NDArray {
+        return NDArray::logspace($start, $stop, $num, $base, $dtype);
+    }
+
+    /**
+     * Create numbers spaced geometrically from start to stop.
+     *
+     * @param float $start The starting value of the sequence
+     * @param float $stop  The end value of the sequence
+     * @param int   $num   Number of samples to generate
+     * @param DType $dtype Data type (default: Float64)
+     */
+    function geomspace(
+        float $start,
+        float $stop,
+        int $num = 50,
+        DType $dtype = DType::Float64,
+    ): NDArray {
+        return NDArray::geomspace($start, $stop, $num, $dtype);
+    }
+
+    /**
+     * Create random samples from a uniform distribution over [0, 1).
+     *
+     * @param array<int> $shape Output shape
+     * @param null|DType $dtype Float dtype (default: Float64)
+     * @param null|int   $seed  Optional seed for deterministic output
+     */
+    function random(array $shape, ?DType $dtype = null, ?int $seed = null): NDArray
+    {
+        return NDArray::random($shape, $dtype, $seed);
+    }
+
+    /**
+     * Create random integer samples from [low, high).
+     *
+     * @param int        $low   Inclusive lower bound
+     * @param int        $high  Exclusive upper bound
+     * @param array<int> $shape Output shape
+     * @param null|DType $dtype Integer dtype (default: Int64)
+     * @param null|int   $seed  Optional seed for deterministic output
+     */
+    function random_int(int $low, int $high, array $shape, ?DType $dtype = null, ?int $seed = null): NDArray
+    {
+        return NDArray::randomInt($low, $high, $shape, $dtype, $seed);
+    }
+
+    /**
+     * Create random samples from a standard normal distribution N(0, 1).
+     *
+     * @param array<int> $shape Output shape
+     * @param null|DType $dtype Float dtype (default: Float64)
+     * @param null|int   $seed  Optional seed for deterministic output
+     */
+    function randn(array $shape, ?DType $dtype = null, ?int $seed = null): NDArray
+    {
+        return NDArray::randn($shape, $dtype, $seed);
+    }
+
+    /**
+     * Create random samples from a normal distribution N(mean, std).
+     *
+     * @param float      $mean  Mean of the distribution
+     * @param float      $std   Standard deviation (must be > 0)
+     * @param array<int> $shape Output shape
+     * @param null|DType $dtype Float dtype (default: Float64)
+     * @param null|int   $seed  Optional seed for deterministic output
+     */
+    function normal(float $mean, float $std, array $shape, ?DType $dtype = null, ?int $seed = null): NDArray
+    {
+        return NDArray::normal($mean, $std, $shape, $dtype, $seed);
+    }
+
+    /**
+     * Create random samples from a uniform distribution over [low, high).
+     *
+     * @param float      $low   Inclusive lower bound
+     * @param float      $high  Exclusive upper bound
+     * @param array<int> $shape Output shape
+     * @param null|DType $dtype Float dtype (default: Float64)
+     * @param null|int   $seed  Optional seed for deterministic output
+     */
+    function uniform(float $low, float $high, array $shape, ?DType $dtype = null, ?int $seed = null): NDArray
+    {
+        return NDArray::uniform($low, $high, $shape, $dtype, $seed);
+    }
+
+    /**
+     * Tile an array by repeating it along each axis.
+     *
+     * Static convenience method that accepts either a PHP array or NDArray.
+     *
+     * @param array<int>|NDArray     $a    Input array or NDArray
+     * @param array<int>|int|NDArray $reps The number of repetitions of A along each axis
+     *
+     * @return NDArray The tiled output array
+     */
+    function tile_array(array|NDArray $a, array|int|NDArray $reps): NDArray
+    {
+        return NDArray::tileArray($a, $reps);
+    }
+
+    /**
+     * Repeat elements of an array.
+     *
+     * Static convenience method that accepts either a PHP array or NDArray.
+     *
+     * @param array<mixed>|NDArray   $a       Input array or NDArray
+     * @param array<int>|int|NDArray $repeats The number of repetitions for each element
+     * @param null|int               $axis    The axis along which to repeat values. By default, use the flattened input array
+     *
+     * @return NDArray Output array which has the same shape as a, except along the given axis
+     */
+    function repeat_array(array|NDArray $a, array|int|NDArray $repeats, ?int $axis = null): NDArray
+    {
+        return NDArray::repeatArray($a, $repeats, $axis);
+    }
+
+    /**
+     * Create a deep copy of the array (or view).
+     *
+     * The returned array is always C-contiguous and owns its data.
+     */
+    function copy(NDArray $a): NDArray
+    {
+        return $a->copy();
+    }
+
+    /**
+     * Cast array to a different data type.
+     *
+     * Returns a new array with the specified dtype. If the target dtype
+     * is the same as the current dtype, this is equivalent to copy().
+     *
+     * @param DType $dtype Target data type
+     *
+     * @return NDArray New array with converted data
+     */
+    function astype(NDArray $a, DType $dtype): NDArray
+    {
+        return $a->astype($dtype);
+    }
+
+    // =============================================================================
+    // HasMath — element-wise arithmetic, ufuncs, bitwise, clamp, min/max, softmax
+    // =============================================================================
+
+    /**
+     * Add another array or scalar to this array.
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar to add
+     *
+     * @return NDArray New array with result
+     */
+    function add(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->add($other);
+    }
+
+    /**
+     * Subtract another array or scalar from this array.
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar to subtract
+     *
+     * @return NDArray New array with result
+     */
+    function subtract(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->subtract($other);
+    }
+
+    /**
+     * Multiply this array by another array or scalar.
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar to multiply by
+     *
+     * @return NDArray New array with result
+     */
+    function multiply(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->multiply($other);
+    }
+
+    /**
+     * Divide this array by another array or scalar.
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar to divide by
+     *
+     * @return NDArray New array with result
+     */
+    function divide(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->divide($other);
+    }
+
+    /**
+     * Compute remainder (modulo) with another array or scalar.
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar
+     *
+     * @return NDArray New array with result
+     */
+    function rem(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->rem($other);
+    }
+
+    /**
+     * Compute modulo with another array or scalar.
+     *
+     * Alias for rem().
+     *
+     * @param Complex|float|int|NDArray $other Array or scalar
+     *
+     * @return NDArray New array with result
+     */
+    function mod(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->mod($other);
+    }
+
+    /**
+     * Compute absolute value element-wise.
+     */
+    function abs(NDArray $a): NDArray
+    {
+        return $a->abs();
+    }
+
+    /**
+     * Compute negation element-wise (-$a).
+     * Not supported for unsigned integers or bool.
+     */
+    function negative(NDArray $a): NDArray
+    {
+        return $a->negative();
+    }
+
+    /**
+     * Extract real part element-wise.
+     *
+     * For complex arrays, returns the real component as float.
+     * For real arrays, returns a copy with the same dtype.
+     */
+    function real(NDArray $a): NDArray
+    {
+        return $a->real();
+    }
+
+    /**
+     * Extract imaginary part element-wise.
+     *
+     * For complex arrays, returns the imaginary component as float.
+     * For real arrays, returns zeros with the same dtype.
+     */
+    function imag(NDArray $a): NDArray
+    {
+        return $a->imag();
+    }
+
+    /**
+     * Compute complex conjugate element-wise.
+     *
+     * For complex arrays, negates the imaginary part.
+     * For real arrays, returns a copy with the same dtype.
+     */
+    function conjugate(NDArray $a): NDArray
+    {
+        return $a->conjugate();
+    }
+
+    /**
+     * Alias for conjugate().
+     */
+    function conj(NDArray $a): NDArray
+    {
+        return $a->conj();
+    }
+
+    /**
+     * Returns bool array: true where element has non-zero imaginary part.
+     *
+     * For complex arrays, checks if imag ≠ 0.
+     * For real arrays, always returns false.
+     */
+    function iscomplex(NDArray $a): NDArray
+    {
+        return $a->iscomplex();
+    }
+
+    /**
+     * Returns bool array: true where element has zero imaginary part.
+     *
+     * For complex arrays, checks if imag = 0.
+     * For real arrays, always returns true.
+     */
+    function isreal(NDArray $a): NDArray
+    {
+        return $a->isreal();
+    }
+
+    /**
+     * Compute phase angle element-wise.
+     *
+     * Returns the counterclockwise angle from the positive real axis.
+     * Always returns Float64 regardless of input dtype.
+     *
+     * @param bool $deg if true, returns angle in degrees; otherwise radians
+     */
+    function angle(NDArray $a, bool $deg = false): NDArray
+    {
+        return $a->angle($deg);
+    }
+
+    /**
+     * Compute square root element-wise.
+     */
+    function sqrt(NDArray $a): NDArray
+    {
+        return $a->sqrt();
+    }
+
+    /**
+     * Compute exponential element-wise.
+     */
+    function exp(NDArray $a): NDArray
+    {
+        return $a->exp();
+    }
+
+    /**
+     * Compute natural logarithm element-wise.
+     */
+    function log(NDArray $a): NDArray
+    {
+        return $a->log();
+    }
+
+    /**
+     * Compute natural logarithm element-wise.
+     *
+     * Alias for log().
+     */
+    function ln(NDArray $a): NDArray
+    {
+        return $a->ln();
+    }
+
+    /**
+     * Compute sine element-wise.
+     */
+    function sin(NDArray $a): NDArray
+    {
+        return $a->sin();
+    }
+
+    /**
+     * Compute cosine element-wise.
+     */
+    function cos(NDArray $a): NDArray
+    {
+        return $a->cos();
+    }
+
+    /**
+     * Compute tangent element-wise.
+     */
+    function tan(NDArray $a): NDArray
+    {
+        return $a->tan();
+    }
+
+    /**
+     * Compute hyperbolic sine element-wise.
+     */
+    function sinh(NDArray $a): NDArray
+    {
+        return $a->sinh();
+    }
+
+    /**
+     * Compute hyperbolic cosine element-wise.
+     */
+    function cosh(NDArray $a): NDArray
+    {
+        return $a->cosh();
+    }
+
+    /**
+     * Compute hyperbolic tangent element-wise.
+     */
+    function tanh(NDArray $a): NDArray
+    {
+        return $a->tanh();
+    }
+
+    /**
+     * Compute arc sine element-wise.
+     */
+    function asin(NDArray $a): NDArray
+    {
+        return $a->asin();
+    }
+
+    /**
+     * Compute arc cosine element-wise.
+     */
+    function acos(NDArray $a): NDArray
+    {
+        return $a->acos();
+    }
+
+    /**
+     * Compute arc tangent element-wise.
+     */
+    function atan(NDArray $a): NDArray
+    {
+        return $a->atan();
+    }
+
+    /**
+     * Compute cube root element-wise.
+     */
+    function cbrt(NDArray $a): NDArray
+    {
+        return $a->cbrt();
+    }
+
+    /**
+     * Compute ceiling element-wise.
+     */
+    function ceil(NDArray $a): NDArray
+    {
+        return $a->ceil();
+    }
+
+    /**
+     * Compute base-2 exponential (2^x) element-wise.
+     */
+    function exp2(NDArray $a): NDArray
+    {
+        return $a->exp2();
+    }
+
+    /**
+     * Compute floor element-wise.
+     */
+    function floor(NDArray $a): NDArray
+    {
+        return $a->floor();
+    }
+
+    /**
+     * Compute base-2 logarithm element-wise.
+     */
+    function log2(NDArray $a): NDArray
+    {
+        return $a->log2();
+    }
+
+    /**
+     * Compute base-10 logarithm element-wise.
+     */
+    function log10(NDArray $a): NDArray
+    {
+        return $a->log10();
+    }
+
+    /**
+     * Compute x^2 (square) element-wise.
+     */
+    function pow2(NDArray $a): NDArray
+    {
+        return $a->pow2();
+    }
+
+    /**
+     * Compute round element-wise.
+     */
+    function round(NDArray $a): NDArray
+    {
+        return $a->round();
+    }
+
+    /**
+     * Compute signum element-wise.
+     */
+    function signum(NDArray $a): NDArray
+    {
+        return $a->signum();
+    }
+
+    /**
+     * Compute reciprocal (1/x) element-wise.
+     */
+    function recip(NDArray $a): NDArray
+    {
+        return $a->recip();
+    }
+
+    /**
+     * Compute ln(1+x) element-wise.
+     *
+     * More accurate than log(1+x) for small x.
+     */
+    function ln1p(NDArray $a): NDArray
+    {
+        return $a->ln1p();
+    }
+
+    /**
+     * Convert radians to degrees element-wise.
+     */
+    function to_degrees(NDArray $a): NDArray
+    {
+        return $a->toDegrees();
+    }
+
+    /**
+     * Convert degrees to radians element-wise.
+     */
+    function to_radians(NDArray $a): NDArray
+    {
+        return $a->toRadians();
+    }
+
+    /**
+     * Compute x^n where n is an integer, element-wise.
+     *
+     * Generally faster than pow() for integer exponents.
+     *
+     * @param int $exp Integer exponent
+     */
+    function powi(NDArray $a, int $exp): NDArray
+    {
+        return $a->powi($exp);
+    }
+
+    /**
+     * Compute x^y where y is a float, element-wise.
+     *
+     * @param float $exp Float exponent
+     */
+    function powf(NDArray $a, float $exp): NDArray
+    {
+        return $a->powf($exp);
+    }
+
+    /**
+     * Compute hypotenuse element-wise.
+     *
+     * @param float $other Scalar value
+     */
+    function hypot(NDArray $a, float $other): NDArray
+    {
+        return $a->hypot($other);
+    }
+
+    /**
+     * Bitwise AND with another array or scalar.
+     *
+     * @param int|NDArray $other Array or scalar
+     *
+     * @return NDArray New array with result
+     */
+    function bitand(NDArray $a, int|NDArray $other): NDArray
+    {
+        return $a->bitand($other);
+    }
+
+    /**
+     * Bitwise OR with another array or scalar.
+     *
+     * @param int|NDArray $other Array or scalar
+     *
+     * @return NDArray New array with result
+     */
+    function bitor(NDArray $a, int|NDArray $other): NDArray
+    {
+        return $a->bitor($other);
+    }
+
+    /**
+     * Bitwise XOR with another array or scalar.
+     *
+     * @param int|NDArray $other Array or scalar
+     *
+     * @return NDArray New array with result
+     */
+    function bitxor(NDArray $a, int|NDArray $other): NDArray
+    {
+        return $a->bitxor($other);
+    }
+
+    /**
+     * Left shift by another array or scalar.
+     *
+     * @param int|NDArray $other Array or scalar (number of bits)
+     *
+     * @return NDArray New array with result
+     */
+    function left_shift(NDArray $a, int|NDArray $other): NDArray
+    {
+        return $a->leftShift($other);
+    }
+
+    /**
+     * Right shift by another array or scalar.
+     *
+     * @param int|NDArray $other Array or scalar (number of bits)
+     *
+     * @return NDArray New array with result
+     */
+    function right_shift(NDArray $a, int|NDArray $other): NDArray
+    {
+        return $a->rightShift($other);
+    }
+
+    /**
+     * Clamp (clip) array values to a specified range.
+     *
+     * Similar to NumPy's clip function. Values outside [min, max] are set
+     * to the nearest boundary.
+     *
+     * @param float $min Minimum value
+     * @param float $max Maximum value
+     *
+     * @throws \InvalidArgumentException If min > max
+     */
+    function clamp(NDArray $a, float|int $min, float|int $max): NDArray
+    {
+        return $a->clamp($min, $max);
+    }
+
+    /**
+     * Clip array values to a specified range.
+     *
+     * Alias for clamp().
+     *
+     * @param float $min Minimum value
+     * @param float $max Maximum value
+     *
+     * @throws \InvalidArgumentException If min > max
+     */
+    function clip(NDArray $a, float|int $min, float|int $max): NDArray
+    {
+        return $a->clip($min, $max);
+    }
+
+    /**
+     * Element-wise minimum of two arrays.
+     *
+     * Compares two arrays element-wise and returns a new array containing
+     * the smaller value at each position. Supports broadcasting.
+     *
+     * @param NDArray $other The array to compare with
+     *
+     * @return NDArray New array with element-wise minimum values
+     */
+    function minimum(NDArray $a, NDArray $other): NDArray
+    {
+        return $a->minimum($other);
+    }
+
+    /**
+     * Element-wise maximum of two arrays.
+     *
+     * Compares two arrays element-wise and returns a new array containing
+     * the larger value at each position. Supports broadcasting.
+     *
+     * @param NDArray $other The array to compare with
+     *
+     * @return NDArray New array with element-wise maximum values
+     */
+    function maximum(NDArray $a, NDArray $other): NDArray
+    {
+        return $a->maximum($other);
+    }
+
+    /**
+     * Compute sigmoid element-wise: 1 / (1 + exp(-x)).
+     */
+    function sigmoid(NDArray $a): NDArray
+    {
+        return $a->sigmoid();
+    }
+
+    /**
+     * Compute softmax along axis: exp(x - max) / sum(exp(x - max)).
+     *
+     * Numerically stable. Default axis -1 (last axis) for typical logits.
+     *
+     * @param int $axis Axis along which to compute softmax
+     */
+    function softmax(NDArray $a, int $axis = -1): NDArray
+    {
+        return $a->softmax($axis);
+    }
+
+    // =============================================================================
+    // HasComparison — element-wise comparisons (Bool result)
+    // =============================================================================
+
+    /**
+     * Element-wise equal comparison. Returns Bool array.
+     */
+    function eq(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->eq($other);
+    }
+
+    /**
+     * Element-wise not-equal comparison. Returns Bool array.
+     */
+    function ne(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->ne($other);
+    }
+
+    /**
+     * Element-wise greater-than comparison. Returns Bool array.
+     */
+    function gt(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->gt($other);
+    }
+
+    /**
+     * Element-wise greater-or-equal comparison. Returns Bool array.
+     */
+    function gte(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->gte($other);
+    }
+
+    /**
+     * Element-wise less-than comparison. Returns Bool array.
+     */
+    function lt(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->lt($other);
+    }
+
+    /**
+     * Element-wise less-or-equal comparison. Returns Bool array.
+     */
+    function lte(NDArray $a, Complex|float|int|NDArray $other): NDArray
+    {
+        return $a->lte($other);
+    }
+
+    // =============================================================================
+    // HasLogical — element-wise logical (Bool result).
+    // =============================================================================
+
+    /**
+     * Element-wise logical AND. Returns Bool array.
+     *
+     * Works with any input type (converts to bool first).
+     * Zero values are treated as false, non-zero as true.
+     *
+     * @see NDArray::and()
+     */
+    function logical_and(NDArray $a, NDArray $other): NDArray
+    {
+        return $a->and($other);
+    }
+
+    /**
+     * Element-wise logical OR. Returns Bool array.
+     *
+     * Works with any input type (converts to bool first).
+     * Zero values are treated as false, non-zero as true.
+     *
+     * @see NDArray::or()
+     */
+    function logical_or(NDArray $a, NDArray $other): NDArray
+    {
+        return $a->or($other);
+    }
+
+    /**
+     * Element-wise logical NOT. Returns Bool array.
+     *
+     * Works with any input type (converts to bool first).
+     * Zero values are treated as false, non-zero as true.
+     *
+     * @see NDArray::not()
+     */
+    function logical_not(NDArray $a): NDArray
+    {
+        return $a->not();
+    }
+
+    /**
+     * Element-wise logical XOR. Returns Bool array.
+     *
+     * Works with any input type (converts to bool first).
+     * Zero values are treated as false, non-zero as true.
+     *
+     * @see NDArray::xor()
+     */
+    function logical_xor(NDArray $a, NDArray $other): NDArray
+    {
+        return $a->xor($other);
+    }
+
+    // =============================================================================
+    // HasReductions — reductions, sort, topk, cumulative, bincount
+    // =============================================================================
+
+    /**
+     * Sum of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to sum. If null, sum over all elements.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     */
+    function sum(NDArray $a, ?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
+    {
+        return $a->sum($axis, $keepdims);
+    }
+
+    /**
+     * Mean of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to compute mean. If null, compute mean of all elements.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return Complex|float|NDArray scalar if axis is null, otherwise an NDArray
+     */
+    function mean(NDArray $a, ?int $axis = null, bool $keepdims = false): Complex|float|NDArray
+    {
+        return $a->mean($axis, $keepdims);
+    }
+
+    /**
+     * Minimum of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to find minimum. If null, find minimum of all elements.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     *
+     * @see NDArray::min() Named `amin` (NumPy-style) so this file does not shadow PHP's `min()`.
+     */
+    function amin(NDArray $a, ?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
+    {
+        return $a->min($axis, $keepdims);
+    }
+
+    /**
+     * Maximum of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to find maximum. If null, find maximum of all elements.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     *
+     * @see NDArray::max() Named `amax` (NumPy-style) so this file does not shadow PHP's `max()`.
+     */
+    function amax(NDArray $a, ?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
+    {
+        return $a->max($axis, $keepdims);
+    }
+
+    /**
+     * Index of minimum value over a given axis.
+     *
+     * @param null|int $axis     Axis along which to find argmin. If null, find argmin of flattened array.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return int|NDArray scalar index if axis is null, otherwise an NDArray of indices
+     */
+    function argmin(NDArray $a, ?int $axis = null, bool $keepdims = false): int|NDArray
+    {
+        return $a->argmin($axis, $keepdims);
+    }
+
+    /**
+     * Index of maximum value over a given axis.
+     *
+     * @param null|int $axis     Axis along which to find argmax. If null, find argmax of flattened array.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return int|NDArray scalar index if axis is null, otherwise an NDArray of indices
+     */
+    function argmax(NDArray $a, ?int $axis = null, bool $keepdims = false): int|NDArray
+    {
+        return $a->argmax($axis, $keepdims);
+    }
+
+    /**
+     * Return a sorted copy of the array.
+     *
+     * @param null|int $axis Axis along which to sort. If null, sort flattened data.
+     * @param SortKind $kind sorting algorithm
+     */
+    function sort(NDArray $a, ?int $axis = -1, SortKind $kind = SortKind::QuickSort): NDArray
+    {
+        return $a->sort($axis, $kind);
+    }
+
+    /**
+     * Return indices that would sort the array.
+     *
+     * @param null|int $axis Axis along which to argsort. If null, argsort flattened data.
+     * @param SortKind $kind sorting algorithm
+     *
+     * @return NDArray int64 indices array
+     */
+    function argsort(NDArray $a, ?int $axis = -1, SortKind $kind = SortKind::QuickSort): NDArray
+    {
+        return $a->argsort($axis, $kind);
+    }
+
+    /**
+     * Return top-k values and indices like PyTorch topk.
+     *
+     * @param int      $k       Number of elements to select
+     * @param null|int $axis    Axis along which to select. If null, flatten first.
+     * @param bool     $largest If true, select largest values; otherwise smallest values
+     * @param bool     $sorted  If true, keep selected values sorted by rank
+     * @param SortKind $kind    Sorting algorithm
+     *
+     * @return array{values: NDArray, indices: NDArray}
+     */
+    function topk(
+        NDArray $a,
+        int $k,
+        ?int $axis = -1,
+        bool $largest = true,
+        bool $sorted = true,
+        SortKind $kind = SortKind::QuickSort,
+    ): array {
+        return $a->topk($k, $axis, $largest, $sorted, $kind);
+    }
+
+    /**
+     * Product of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to compute product. If null, compute product of all elements.
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     */
+    function product(NDArray $a, ?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
+    {
+        return $a->product($axis, $keepdims);
+    }
+
+    /**
+     * Cumulative sum of array elements.
+     *
+     * @param null|int $axis Axis along which to compute cumulative sum. If null, flatten and return 1D.
+     */
+    function cumsum(NDArray $a, ?int $axis = null): NDArray
+    {
+        return $a->cumsum($axis);
+    }
+
+    /**
+     * Cumulative product of array elements.
+     *
+     * @param null|int $axis Axis along which to compute cumulative product. If null, flatten and return 1D.
+     */
+    function cumprod(NDArray $a, ?int $axis = null): NDArray
+    {
+        return $a->cumprod($axis);
+    }
+
+    /**
+     * Variance of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to compute variance. If null, compute variance of all elements.
+     * @param int      $ddof     delta degrees of freedom (0 for population, 1 for sample)
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return float|NDArray scalar if axis is null, otherwise an NDArray
+     */
+    function variance(NDArray $a, ?int $axis = null, int $ddof = 0, bool $keepdims = false): float|NDArray
+    {
+        return $a->var($axis, $ddof, $keepdims);
+    }
+
+    /**
+     * Standard deviation of array elements over a given axis.
+     *
+     * @param null|int $axis     Axis along which to compute std. If null, compute std of all elements.
+     * @param int      $ddof     delta degrees of freedom (0 for population, 1 for sample)
+     * @param bool     $keepdims if true, the reduced axis is retained with size 1
+     *
+     * @return float|NDArray scalar if axis is null, otherwise an NDArray
+     */
+    function std(NDArray $a, ?int $axis = null, int $ddof = 0, bool $keepdims = false): float|NDArray
+    {
+        return $a->std($axis, $ddof, $keepdims);
+    }
+
+    /**
+     * Count occurrences of non-negative integer values in flattened input.
+     *
+     * @param null|int $minlength Minimum output length
+     *
+     * @return NDArray Int64 counts array
+     */
+    function bincount(NDArray $a, ?int $minlength = null): NDArray
+    {
+        return $a->bincount($minlength);
+    }
+
+    // =============================================================================
+    // HasShapeOps — shape, views, pad, tile, repeat
+    // =============================================================================
+
+    /**
+     * Pad an array.
+     *
+     * @param array<array{int,int}|int>|array{int,int}|int $padWidth       Number of elements to pad on each side of each axis.
+     *                                                                     - int: pad same amount on all sides of every axis
+     *                                                                     - array{int,int}: pad [before, after] for all axes
+     *                                                                     - array<int|array{int,int}>: per-axis pad (int or [before, after] per axis)
+     * @param PadMode                                      $mode           padding mode
+     * @param array<bool|float|int>|bool|float|int         $constantValues constant value to pad with (used for PadMode::Constant)
+     *
+     * @return NDArray padded array
+     */
+    function pad(NDArray $a, array|int $padWidth, PadMode $mode = PadMode::Constant, array|bool|float|int $constantValues = 0): NDArray
+    {
+        return $a->pad($padWidth, $mode, $constantValues);
+    }
+
+    /**
+     * Reshape the array to a new shape.
+     *
+     * Returns a new array with the specified shape.
+     * Supports both C-order (row-major, order='C') and F-order (column-major, order='F').
+     *
+     * For contiguous arrays, this returns a zero-copy view with updated metadata.
+     * For non-contiguous arrays, data is copied to make it contiguous first.
+     *
+     * @param array<int> $newShape New shape
+     * @param string     $order    Memory layout: 'C' for row-major, 'F' for column-major
+     */
+    function reshape(NDArray $a, array $newShape, string $order = 'C'): NDArray
+    {
+        return $a->reshape($newShape, $order);
+    }
+
+    /**
+     * Transpose the array.
+     *
+     * For 2D arrays, swaps rows and columns.
+     * For nD arrays, reverses the order of all axes.
+     *
+     * For contiguous arrays, this is a zero-copy operation returning a view.
+     * For non-contiguous arrays, data is copied first.
+     */
+    function transpose(NDArray $a): NDArray
+    {
+        return $a->transpose();
+    }
+
+    /**
+     * Swap two axes of the array.
+     *
+     * This is a zero-copy operation that returns a view with swapped
+     * shape and stride metadata. The underlying data is shared.
+     *
+     * @param int $axis1 First axis to swap
+     * @param int $axis2 Second axis to swap
+     */
+    function swapaxes(NDArray $a, int $axis1, int $axis2): NDArray
+    {
+        return $a->swapaxes($axis1, $axis2);
+    }
+
+    /**
+     * Permute axes of the array.
+     *
+     * Reorders the axes according to the given permutation.
+     * For example, permute(1, 0) on a 2D array is equivalent to transpose().
+     *
+     * @param int ...$axes New order of axes
+     */
+    function permute(NDArray $a, int ...$axes): NDArray
+    {
+        return $a->permute(...$axes);
+    }
+
+    /**
+     * Merge axes by combining take into into.
+     *
+     * Merges the axis 'take' into axis 'into' by folding the dimensions.
+     * The 'take' axis is removed and its size is multiplied into the 'into' axis.
+     * This is a zero-copy operation that returns a view with updated metadata.
+     *
+     * For example, on an array with shape [2, 3, 4]:
+     * - mergeaxes(1, 0) merges axis 1 into axis 0, resulting in shape [6, 4]
+     * - mergeaxes(0, 1) merges axis 0 into axis 1, resulting in shape [3, 8]
+     *
+     * @param int $take Axis to merge from (will be removed)
+     * @param int $into Axis to merge into (size will be multiplied)
+     */
+    function mergeaxes(NDArray $a, int $take, int $into): NDArray
+    {
+        return $a->mergeaxes($take, $into);
+    }
+
+    /**
+     * Reverse the order of elements in an array along the given axis or axes.
+     *
+     * @param null|array<int>|int $axes Axis or axes to flip. If null, flip over all axes.
+     */
+    function flip(NDArray $a, array|int|null $axes = null): NDArray
+    {
+        return $a->flip($axes);
+    }
+
+    /**
+     * Insert a new axis at the specified position.
+     *
+     * The new axis always has length 1. This is a zero-copy operation that returns
+     * a view with updated metadata.
+     *
+     * @param int $axis Position where new axis is inserted
+     */
+    function insertaxis(NDArray $a, int $axis): NDArray
+    {
+        return $a->insertaxis($axis);
+    }
+
+    /**
+     * Flatten the array to 1D.
+     *
+     * Always returns a copy in C-order (row-major).
+     */
+    function flatten(NDArray $a): NDArray
+    {
+        return $a->flatten();
+    }
+
+    /**
+     * Ravel the array to 1D.
+     *
+     * Similar to flatten() but returns a view if the array is contiguous.
+     * For non-contiguous arrays, data is copied to make it contiguous.
+     *
+     * @param string $order Memory layout: 'C' for row-major, 'F' for column-major
+     */
+    function ravel(NDArray $a, string $order = 'C'): NDArray
+    {
+        return $a->ravel($order);
+    }
+
+    /**
+     * Remove axes of length 1 from the array.
+     *
+     * If no axes are specified, removes all length-1 axes (NumPy behavior).
+     * This is a zero-copy operation that returns a view with updated metadata.
+     *
+     * @param null|array<int> $axes Specific axes to squeeze (null for all)
+     */
+    function squeeze(NDArray $a, ?array $axes = null): NDArray
+    {
+        return $a->squeeze($axes);
+    }
+
+    /**
+     * Expand dimensions by inserting a new axis.
+     *
+     * Alias for insertaxis().
+     *
+     * @param int $axis Position where new axis is inserted
+     */
+    function expand_dims(NDArray $a, int $axis): NDArray
+    {
+        return $a->expandDims($axis);
+    }
+
+    /**
+     * Construct an array by repeating A the number of times given by reps.
+     *
+     * @param array<int>|int|NDArray $reps the number of repetitions of A along each axis
+     *
+     * @return NDArray the tiled output array
+     */
+    function tile(NDArray $a, array|int|NDArray $reps): NDArray
+    {
+        return $a->tile($reps);
+    }
+
+    /**
+     * Repeat elements of an array.
+     *
+     * @param array<int>|int|NDArray $repeats the number of repetitions for each element
+     * @param null|int               $axis    The axis along which to repeat values. By default, use the flattened input array.
+     *
+     * @return NDArray output array which has the same shape as a, except along the given axis
+     */
+    function repeat(NDArray $a, array|int|NDArray $repeats, ?int $axis = null): NDArray
+    {
+        return $a->repeat($repeats, $axis);
+    }
+
+    // =============================================================================
+    // HasStacking — concatenate, stack, split
+    // =============================================================================
+
+    /**
+     * Join arrays along an existing axis.
+     *
+     * All arrays must have the same shape except for the dimension along axis.
+     *
+     * @param array<NDArray> $arrays Arrays to concatenate
+     * @param int            $axis   Axis along which to join (default 0)
+     */
+    function concatenate(array $arrays, int $axis = 0): NDArray
+    {
+        return NDArray::concatenate($arrays, $axis);
+    }
+
+    /**
+     * Stack arrays along a new axis.
+     *
+     * All arrays must have identical shapes.
+     *
+     * @param array<NDArray> $arrays Arrays to stack
+     * @param int            $axis   Axis in the result at which the arrays are stacked
+     */
+    function stack(array $arrays, int $axis = 0): NDArray
+    {
+        return NDArray::stack($arrays, $axis);
+    }
+
+    /**
+     * Stack arrays vertically (along axis 0).
+     *
+     * Equivalent to concatenate(arrays, axis=0).
+     *
+     * @param array<NDArray> $arrays Arrays to stack
+     */
+    function vstack(array $arrays): NDArray
+    {
+        return NDArray::vstack($arrays);
+    }
+
+    /**
+     * Stack arrays horizontally (along axis 1).
+     *
+     * Equivalent to concatenate(arrays, axis=1).
+     *
+     * @param array<NDArray> $arrays Arrays to stack
+     */
+    function hstack(array $arrays): NDArray
+    {
+        return NDArray::hstack($arrays);
+    }
+
+    /**
+     * Split array along axis.
+     *
+     * If $indicesOrSections is an integer N, split into N equal parts (axis length must be divisible by N).
+     * If it is an array of indices, split at those positions.
+     *
+     * @param array<int>|int $indicesOrSections Number of equal parts, or array of split indices
+     * @param int            $axis              Axis along which to split
+     *
+     * @return array<NDArray> List of sub-arrays (views)
+     */
+    function split(NDArray $a, array|int $indicesOrSections, int $axis = 0): array
+    {
+        return $a->split($indicesOrSections, $axis);
+    }
+
+    /**
+     * Split array vertically (along axis 0).
+     *
+     * @param array<int>|int $indicesOrSections Number of equal parts or split indices
+     *
+     * @return array<NDArray>
+     */
+    function vsplit(NDArray $a, array|int $indicesOrSections): array
+    {
+        return $a->vsplit($indicesOrSections);
+    }
+
+    /**
+     * Split array horizontally (along axis 1).
+     *
+     * @param array<int>|int $indicesOrSections Number of equal parts or split indices
+     *
+     * @return array<NDArray>
+     */
+    function hsplit(NDArray $a, array|int $indicesOrSections): array
+    {
+        return $a->hsplit($indicesOrSections);
+    }
+
+    // =============================================================================
+    // HasIndexing — get/set, take/put, scatter, where
+    // =============================================================================
+
+    /**
+     * Access elements by index.
+     *
+     * Full indices (count === ndim) return a scalar via FFI read.
+     * Partial indices (count < ndim) return a view (pure PHP, zero FFI).
+     *
+     * Supports negative indices: -1 refers to the last element, -2 to second-to-last, etc.
+     *
+     * @param int ...$indices One or more dimension indices
+     *
+     * @return bool|float|int|NDArray Scalar for full indexing, view for partial
+     */
+    function get(NDArray $a, int ...$indices): bool|Complex|float|int|NDArray
+    {
+        return $a->get(...$indices);
+    }
+
+    /**
+     * Set a scalar value at the given indices.
+     *
+     * Requires full indexing (count === ndim).
+     *
+     * Supports negative indices: -1 refers to the last element, -2 to second-to-last, etc.
+     *
+     * @param array<int>             $indices Indices for each dimension
+     * @param bool|Complex|float|int $value   Value to set
+     */
+    function set(NDArray $a, array $indices, bool|Complex|float|int $value): void
+    {
+        $a->set($indices, $value);
+    }
+
+    /**
+     * Set a scalar value using a logical flat index (C-order) for this array/view.
+     *
+     * Supports negative indices: -1 refers to the last logical element.
+     *
+     * @param int            $flatIndex Logical flat index into this array/view
+     * @param bool|float|int $value     Value to set
+     */
+    function set_at(NDArray $a, int $flatIndex, bool|Complex|float|int $value): void
+    {
+        $a->setAt($flatIndex, $value);
+    }
+
+    /**
+     * Get a scalar value using a logical flat index (C-order) for this array/view.
+     *
+     * Supports negative indices: -1 refers to the last logical element.
+     *
+     * @param int $flatIndex Logical flat index into this array/view
+     *
+     * @return bool|float|int The value at the specified flat index
+     */
+    function get_at(NDArray $a, int $flatIndex): bool|Complex|float|int
+    {
+        return $a->getAt($flatIndex);
+    }
+
+    /**
+     * Gather values by indices.
+     *
+     * If axis is null, gathers from logical flattened view (C-order).
+     * If axis is provided, delegates to takeAlongAxis semantics.
+     *
+     * @param array<array<int>|int>|NDArray $indices
+     */
+    function take(NDArray $a, array|NDArray $indices, ?int $axis = null): NDArray
+    {
+        return $a->take($indices, $axis);
+    }
+
+    /**
+     * Gather values along an axis using per-position indices.
+     *
+     * @param array<array<int>|int>|NDArray $indices
+     */
+    function take_along_axis(NDArray $a, array|NDArray $indices, int $axis): NDArray
+    {
+        return $a->takeAlongAxis($indices, $axis);
+    }
+
+    /**
+     * Scatter values by flattened indices and return a mutated copy.
+     *
+     * @param array<array<int>|int>|NDArray $indices
+     * @param string                        $mode    Currently supports only 'raise'
+     */
+    function put(NDArray $a, array|NDArray $indices, bool|float|int|NDArray $values, string $mode = 'raise'): NDArray
+    {
+        return $a->put($indices, $values, $mode);
+    }
+
+    /**
+     * Scatter values along an axis and return a mutated copy.
+     *
+     * @param array<array<int>|int>|NDArray $indices
+     */
+    function put_along_axis(NDArray $a, array|NDArray $indices, bool|float|int|NDArray $values, int $axis): NDArray
+    {
+        return $a->putAlongAxis($indices, $values, $axis);
+    }
+
+    /**
+     * Add updates by flattened indices and return a mutated copy.
+     *
+     * @param array<array<int>|int>|NDArray $indices
+     */
+    function scatter_add(NDArray $a, array|NDArray $indices, bool|float|int|NDArray $updates): NDArray
+    {
+        return $a->scatterAdd($indices, $updates);
+    }
+
+    /**
+     * Select values from x and y based on a boolean condition.
+     *
+     * @param bool|float|int|NDArray $condition Bool NDArray or scalar condition
+     * @param bool|float|int|NDArray $x         Values where condition is true
+     * @param bool|float|int|NDArray $y         Values where condition is false
+     */
+    function where(bool|float|int|NDArray $condition, bool|float|int|NDArray $x, bool|float|int|NDArray $y): NDArray
+    {
+        return NDArray::where($condition, $x, $y);
+    }
+
+    // =============================================================================
+    // HasSlicing — slice views, assign
+    // =============================================================================
+
+    /**
+     * Create a view of the array using slice syntax.
+     *
+     * Selectors can be integers (to reduce dimensions) or slice strings
+     * (e.g., "0:5", ":", "::2") to subset dimensions.
+     *
+     * @param array<int|string> $selection List of selectors for each dimension
+     *
+     * @return NDArray A new view sharing the same data
+     */
+    function slice(NDArray $a, array $selection): NDArray
+    {
+        return $a->slice($selection);
+    }
+
+    /**
+     * Assign values to the current array/view.
+     *
+     * Supports scalar assignment (fill) or array assignment (from PHP array or NDArray).
+     *
+     * @param mixed $value Scalar value or array/NDArray
+     */
+    function assign(NDArray $a, mixed $value): void
+    {
+        $a->assign($value);
+    }
+}
+
+namespace PhpMlKit\NDArray\Linalg {
+    use PhpMlKit\NDArray\Complex;
+    use PhpMlKit\NDArray\NDArray;
+
+    /**
+     * Compute vector or matrix norm.
+     *
+     * Supported orders:
+     * - 1
+     * - 2
+     * - INF
+     * - -INF
+     * - 'fro' (matrix only, axis=null)
+     *
+     * @param null|float|int|string $ord      Norm order
+     * @param null|int              $axis     Reduction axis. If null, reduces all elements
+     * @param bool                  $keepdims Keep reduced axis with size 1 (axis mode only)
+     */
+    function norm(NDArray $a, float|int|string|null $ord = null, ?int $axis = null, bool $keepdims = false): float|NDArray
+    {
+        return $a->norm($ord, $axis, $keepdims);
+    }
+
+    /**
+     * Generalized dot product for 1D and 2D operands.
+     *
+     * Operand dtypes are promoted to a common type before the operation. Shape rules:
+     * - **1D × 1D**: inner product → scalar
+     * - **2D × 2D**: matrix product → 2D array
+     * - **1D × 2D** or **2D × 1D**: vector–matrix product → 1D array
+     *
+     * @param NDArray $other The other array
+     *
+     * @return Complex|float|int|NDArray scalar when the result is 0-D, otherwise an NDArray
+     */
+    function dot(NDArray $a, NDArray $other): Complex|float|int|NDArray
+    {
+        return $a->dot($other);
+    }
+
+    /**
+     * Matrix multiplication (`@`) for 1D and 2D operands.
+     *
+     * Operand dtypes are promoted to a common type before the operation. Supported shapes:
+     * - **2D × 2D**: matrix × matrix → 2D array
+     * - **2D × 1D** or **1D × 2D**: matrix × vector → 1D array
+     * - **1D × 1D**: inner product → scalar (0-D result unpacked to a PHP scalar or `Complex`)
+     *
+     * Operands with more than two dimensions are not supported.
+     *
+     * @param NDArray $other The other array
+     *
+     * @return Complex|float|int|NDArray scalar when the result is 0-D, otherwise an NDArray
+     */
+    function matmul(NDArray $a, NDArray $other): Complex|float|int|NDArray
+    {
+        return $a->matmul($other);
+    }
+
+    /**
+     * Extract diagonal elements from a 2D array.
+     *
+     * Returns a 1D array containing the diagonal.
+     *
+     * @param int $offset Diagonal offset. 0 = main diagonal, positive = upper diagonal, negative = lower diagonal
+     */
+    function diagonal(NDArray $a, int $offset = 0): NDArray
+    {
+        return $a->diagonal($offset);
+    }
+
+    /**
+     * Extract a diagonal or construct a diagonal array.
+     *
+     * If the input is 1D: returns a 2D array with the input as the diagonal.
+     * If the input is 2D: returns a 1D array containing the diagonal.
+     *
+     * @param int $offset Diagonal offset. 0 = main diagonal, positive = upper diagonal, negative = lower diagonal
+     */
+    function diag(NDArray $a, int $offset = 0): NDArray
+    {
+        return $a->diag($offset);
+    }
+
+    /**
+     * Compute trace (sum of diagonal elements).
+     *
+     * @return Complex|float|int scalar value
+     */
+    function trace(NDArray $a): Complex|float|int
+    {
+        return $a->trace();
+    }
+
+    /**
+     * Solve a linear system A * x = b.
+     *
+     * A must be a 2D square matrix. b can be 1D or 2D.
+     *
+     * @param NDArray $b Right-hand side array
+     */
+    function solve(NDArray $a, NDArray $b): NDArray
+    {
+        return $a->solve($b);
+    }
+
+    /**
+     * Compute the inverse of a square matrix.
+     *
+     * Requires a 2D square matrix.
+     */
+    function inv(NDArray $a): NDArray
+    {
+        return $a->inv();
+    }
+
+    /**
+     * Compute the determinant of a square matrix.
+     *
+     * Requires a 2D square matrix.
+     */
+    function det(NDArray $a): Complex|float|int
+    {
+        return $a->det();
+    }
+
+    /**
+     * Compute Singular Value Decomposition (SVD).
+     *
+     * Decomposes matrix A into U * S * V^T where:
+     * - U is an orthogonal matrix (left singular vectors)
+     * - S is a diagonal matrix of singular values (returned as 1D array)
+     * - V^T is an orthogonal matrix (right singular vectors transposed)
+     *
+     * @param bool $computeUv If true, compute U and V^T matrices. If false, only compute singular values.
+     *
+     * @return ($computeUv is true ? array{0: NDArray, 1: NDArray, 2: NDArray} : NDArray)
+     */
+    function svd(NDArray $a, bool $computeUv = true): array|NDArray
+    {
+        return $a->svd($computeUv);
+    }
+
+    /**
+     * Compute QR decomposition.
+     *
+     * Decomposes matrix A into Q * R where Q is orthogonal and R is upper triangular.
+     *
+     * @return array{0: NDArray, 1: NDArray} [Q, R]
+     */
+    function qr(NDArray $a): array
+    {
+        return $a->qr();
+    }
+
+    /**
+     * Compute eigenvalue decomposition.
+     *
+     * Decomposes square matrix A into eigenvalues and right eigenvectors:
+     * A * v_i = lambda_i * v_i
+     *
+     * For real input matrices, eigenvalues and eigenvectors are complex.
+     * For complex input matrices, output type matches input type.
+     *
+     * @return array{0: NDArray, 1: NDArray} [eigenvalues, eigenvectors]
+     */
+    function eig(NDArray $a): array
+    {
+        return $a->eig();
+    }
+
+    /**
+     * Compute eigenvalues only (no eigenvectors) for a general matrix.
+     *
+     * For real input matrices, eigenvalues are complex.
+     * For complex input matrices, output type matches input type.
+     */
+    function eigvals(NDArray $a): NDArray
+    {
+        return $a->eigvals();
+    }
+
+    /**
+     * Compute eigenvalue decomposition for a Hermitian/symmetric matrix.
+     *
+     * Eigenvalues are always real. Eigenvectors have the same type as input.
+     *
+     * @param bool $upper If true, use upper triangular part. If false, use lower.
+     *
+     * @return array{0: NDArray, 1: NDArray} [eigenvalues, eigenvectors]
+     */
+    function eigh(NDArray $a, bool $upper = false): array
+    {
+        return $a->eigh($upper);
+    }
+
+    /**
+     * Compute eigenvalues only (no eigenvectors) for a Hermitian/symmetric matrix.
+     *
+     * Eigenvalues are always real.
+     *
+     * @param bool $upper If true, use upper triangular part. If false, use lower.
+     */
+    function eigvalsh(NDArray $a, bool $upper = false): NDArray
+    {
+        return $a->eigvalsh($upper);
+    }
+
+    /**
+     * Compute Cholesky decomposition.
+     *
+     * For a Hermitian positive-definite matrix A:
+     * - upper=false (default): returns L such that A = L * L^H
+     * - upper=true: returns U such that A = U^H * U
+     */
+    function cholesky(NDArray $a, bool $upper = false): NDArray
+    {
+        return $a->cholesky($upper);
+    }
+
+    /**
+     * Solve a least-squares problem min ||Ax - b||_2.
+     *
+     * Returns [x, residuals, rank, s] where:
+     * - x is the least-squares solution
+     * - residuals is the sum of residuals (or null if not applicable)
+     * - rank is the effective rank of A
+     * - s is the singular values of A
+     *
+     * @return array{0: NDArray, 1: null|NDArray, 2: int, 3: NDArray}
+     */
+    function lstsq(NDArray $a, NDArray $b): array
+    {
+        return $a->lstsq($b);
+    }
+
+    /**
+     * Alias for lstsq().
+     *
+     * @return array{0: NDArray, 1: null|NDArray, 2: int, 3: NDArray}
+     */
+    function least_squares(NDArray $a, NDArray $b): array
+    {
+        return $a->leastSquares($b);
+    }
+
+    /**
+     * Compute the Moore-Penrose pseudo-inverse of a matrix.
+     *
+     * @param null|float $rcond Cutoff for small singular values. Default uses machine precision.
+     */
+    function pinv(NDArray $a, ?float $rcond = null): NDArray
+    {
+        return $a->pinv($rcond);
+    }
+
+    /**
+     * Compute the 2-norm condition number of a matrix.
+     */
+    function cond(NDArray $a): Complex|float|int
+    {
+        return $a->cond();
+    }
+
+    /**
+     * Compute the rank of a matrix using SVD.
+     *
+     * @param null|float $tol threshold below which SVD values are considered zero
+     */
+    function rank(NDArray $a, ?float $tol = null): int
+    {
+        return $a->rank($tol);
+    }
+}
+
+namespace PhpMlKit\NDArray\Fft {
+    use PhpMlKit\NDArray\NDArray;
+    use PhpMlKit\NDArray\Normalization;
+
+    /**
+     * Complex discrete Fourier transform along one axis. Real inputs are promoted to complex.
+     *
+     * @param null|int $n Transform length along `axis` (null = current size)
+     */
+    function fft(NDArray $a, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->fft($n, $axis, $norm);
+    }
+
+    /**
+     * Inverse complex FFT along one axis (expects complex dtype).
+     */
+    function ifft(NDArray $a, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->ifft($n, $axis, $norm);
+    }
+
+    /**
+     * N-dimensional complex FFT. `axes` null or empty transforms all axes in order.
+     *
+     * @param null|array<int> $axes Axis indices (negative indices allowed)
+     */
+    function fftn(NDArray $a, ?array $axes = null, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->fftn($axes, $norm);
+    }
+
+    /**
+     * N-dimensional inverse complex FFT.
+     *
+     * @param null|array<int> $axes Axis indices (negative indices allowed)
+     */
+    function ifftn(NDArray $a, ?array $axes = null, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->ifftn($axes, $norm);
+    }
+
+    /**
+     * Real-input FFT along `axis`; result is complex with length `n//2+1` on that axis.
+     */
+    function rfft(NDArray $a, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->rfft($n, $axis, $norm);
+    }
+
+    /**
+     * Inverse real FFT: Hermitian spectrum → real. `n` is the real length along `axis` (null = inferred).
+     */
+    function irfft(NDArray $a, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->irfft($n, $axis, $norm);
+    }
+
+    /**
+     * 2-D FFT on the last two axes (requires `ndim >= 2`).
+     */
+    function fft2(NDArray $a, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->fft2($norm);
+    }
+
+    /**
+     * 2-D inverse FFT on the last two axes (requires `ndim >= 2`).
+     */
+    function ifft2(NDArray $a, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->ifft2($norm);
+    }
+
+    /**
+     * Real discrete cosine transform along one axis.
+     *
+     * @param int      $type DCT-I … DCT-IV (`1` … `4`). Default `2` matches SciPy `dct(..., type=2)`.
+     * @param null|int $n    Length along `axis` (null = current size)
+     */
+    function dct(NDArray $a, int $type = 2, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->dct($type, $n, $axis, $norm);
+    }
+
+    /**
+     * Inverse DCT along one axis (pairs with {@see NDArray::dct()} for the same `$type`).
+     */
+    function idct(NDArray $a, int $type = 2, ?int $n = null, int $axis = -1, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->idct($type, $n, $axis, $norm);
+    }
+
+    /**
+     * N-dimensional DCT. `axes` null or empty applies along every axis in order.
+     *
+     * @param null|array<int> $axes Axis indices (negative indices allowed)
+     */
+    function dctn(NDArray $a, ?array $axes = null, int $type = 2, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->dctn($axes, $type, $norm);
+    }
+
+    /**
+     * N-dimensional inverse DCT.
+     *
+     * @param null|array<int> $axes Axis indices (negative indices allowed)
+     */
+    function idctn(NDArray $a, ?array $axes = null, int $type = 2, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->idctn($axes, $type, $norm);
+    }
+
+    /**
+     * 2-D DCT on the last two axes (requires `ndim >= 2`).
+     */
+    function dct2(NDArray $a, int $type = 2, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->dct2($type, $norm);
+    }
+
+    /**
+     * 2-D inverse DCT on the last two axes (requires `ndim >= 2`).
+     */
+    function idct2(NDArray $a, int $type = 2, Normalization $norm = Normalization::Backward): NDArray
+    {
+        return $a->idct2($type, $norm);
+    }
+}
+
+namespace PhpMlKit\NDArray\Windows {
+    use PhpMlKit\NDArray\NDArray;
+
+    function bartlett(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::bartlett($m, $periodic);
+    }
+
+    function blackman(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::blackman($m, $periodic);
+    }
+
+    function bohman(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::bohman($m, $periodic);
+    }
+
+    function boxcar(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::boxcar($m, $periodic);
+    }
+
+    function hamming(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::hamming($m, $periodic);
+    }
+
+    function hanning(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::hanning($m, $periodic);
+    }
+
+    function hann(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::hann($m, $periodic);
+    }
+
+    function kaiser(int $m, float $beta, bool $periodic = false): NDArray
+    {
+        return NDArray::kaiser($m, $beta, $periodic);
+    }
+
+    function lanczos(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::lanczos($m, $periodic);
+    }
+
+    function triang(int $m, bool $periodic = false): NDArray
+    {
+        return NDArray::triang($m, $periodic);
+    }
+}

--- a/src/Slice.php
+++ b/src/Slice.php
@@ -72,13 +72,9 @@ final class Slice
     {
         $step = $this->step;
 
-        // Default start
         $start = $this->start ?? 0;
-
-        // Default stop
         $stop = $this->stop ?? $dimSize;
 
-        // Handle negative indices
         if ($start < 0) {
             $start += $dimSize;
         }
@@ -86,20 +82,15 @@ final class Slice
             $stop += $dimSize;
         }
 
-        // Clamp indices to bounds [0, dimSize]
-        // NumPy behavior: slices clamp, they don't throw out-of-bounds
         $start = max(0, min($dimSize, $start));
         $stop = max(0, min($dimSize, $stop));
 
-        // If start >= stop (with positive step), result is empty
         if ($start >= $stop) {
             return ['start' => $start, 'stop' => $start, 'step' => $step, 'shape' => 0];
         }
 
-        // Calculate number of steps
-        // shape = ceil((stop - start) / step)
         $diff = $stop - $start;
-        $shape = (int) ceil($diff / $step);
+        $shape = (int) \ceil($diff / $step);
 
         return [
             'start' => $start,

--- a/src/Traits/CreatesArrays.php
+++ b/src/Traits/CreatesArrays.php
@@ -364,9 +364,9 @@ trait CreatesArrays
         // Calculate the shape
         $num = 0;
         if ($step > 0 && $start < $stop) {
-            $num = (int) ceil(($stop - $start) / $step);
+            $num = (int) \ceil(($stop - $start) / $step);
         } elseif ($step < 0 && $start > $stop) {
-            $num = (int) ceil(($start - $stop) / -$step);
+            $num = (int) \ceil(($start - $stop) / -$step);
         }
 
         return new self($outHandle, new ArrayMetadata([$num]), $dtype);

--- a/tests/Integration/BatchProcessingTest.php
+++ b/tests/Integration/BatchProcessingTest.php
@@ -59,7 +59,7 @@ final class BatchProcessingTest extends TestCase
 
         $batchSize = 3;
         $numSamples = $dataset->shape()[0];
-        $numBatches = (int) ceil($numSamples / $batchSize);
+        $numBatches = (int) \ceil($numSamples / $batchSize);
 
         $batches = [];
         for ($i = 0; $i < $numBatches; ++$i) {

--- a/tests/Unit/ComplexTest.php
+++ b/tests/Unit/ComplexTest.php
@@ -916,8 +916,8 @@ final class ComplexTest extends TestCase
 
         $abs = $a->abs();
         $absValues = $abs->toArray();
-        $this->assertEqualsWithDelta(hypot(-1, -2), $absValues[0][0], 0.0001);
-        $this->assertEqualsWithDelta(hypot(-3, 4), $absValues[0][1], 0.0001);
+        $this->assertEqualsWithDelta(\hypot(-1, -2), $absValues[0][0], 0.0001);
+        $this->assertEqualsWithDelta(\hypot(-3, 4), $absValues[0][1], 0.0001);
     }
 
     public function testPureRealComplexArray(): void

--- a/tests/Unit/LinearAlgebraTest.php
+++ b/tests/Unit/LinearAlgebraTest.php
@@ -1271,9 +1271,9 @@ class LinearAlgebraTest extends TestCase
 
         // Eigenvalues are ±i (in some order)
         $this->assertEqualsWithDelta(0.0, $eigvals[0]->real, 1e-10);
-        $this->assertEqualsWithDelta(1.0, abs($eigvals[0]->imag), 1e-10);
+        $this->assertEqualsWithDelta(1.0, \abs($eigvals[0]->imag), 1e-10);
         $this->assertEqualsWithDelta(0.0, $eigvals[1]->real, 1e-10);
-        $this->assertEqualsWithDelta(1.0, abs($eigvals[1]->imag), 1e-10);
+        $this->assertEqualsWithDelta(1.0, \abs($eigvals[1]->imag), 1e-10);
     }
 
     public function testEigVerifyAvEqualsLambdaV(): void
@@ -1422,9 +1422,9 @@ class LinearAlgebraTest extends TestCase
         $this->assertSame(DType::Complex128, $eigvals->dtype());
 
         $this->assertEqualsWithDelta(0.0, $eigvals[0]->real, 1e-10);
-        $this->assertEqualsWithDelta(1.0, abs($eigvals[0]->imag), 1e-10);
+        $this->assertEqualsWithDelta(1.0, \abs($eigvals[0]->imag), 1e-10);
         $this->assertEqualsWithDelta(0.0, $eigvals[1]->real, 1e-10);
-        $this->assertEqualsWithDelta(1.0, abs($eigvals[1]->imag), 1e-10);
+        $this->assertEqualsWithDelta(1.0, \abs($eigvals[1]->imag), 1e-10);
     }
 
     public function testEigvalsComplexMatrix(): void


### PR DESCRIPTION
This PR introduces a documented set of namespaced functions that delegate to `NDArray`. 

## Motivation and Context

Some callers prefer a functional style over chaining on an object, and small pipelines read cleanly when the array is passed through plain functions; that style also lines up well with language affordances such as the pipe operator in PHP 8.5, where a sequence of transforms is easier to express as functions than as repeated method calls. The proxies stay thin wrappers over the existing class API so behavior, semantics, and tests stay centralized on `NDArray` without a second implementation path.

## What’s Changed

- Namespaced global functions that mirror `NDArray` factories, reductions, element-wise and structural operations, and related helpers, all delegating to the class.
- Sub-namespaces for linear algebra, FFT/DCT, and window functions so imports stay grouped and readable.
- API reference page that exhaustively maps those functions to the existing method documentation, plus sidebar and index links so the surface is discoverable.
- PHP CS Fixer configuration updated so leading backslashes on selected PHP builtins are not stripped where the package defines same-named functions in the `NDArray` namespace.

## Breaking Changes
None.