### PR TITLE
Optional axis argument for NDArray::shape() with negative indexing

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -44,7 +44,7 @@ Complete reference for all NDArray classes and methods.
 - `NDArray::random()` - Random values
 
 **Properties:**
-- `shape()` - Get dimensions
+- `shape()`, `shape(?int $axis)` - Full shape list, or length of one axis (`-1` = last)
 - `dtype()` - Get data type
 - `size()` - Total elements
 

--- a/docs/api/ndarray-class.md
+++ b/docs/api/ndarray-class.md
@@ -31,22 +31,33 @@ Methods to inspect array metadata.
 
 ### shape()
 
-Returns the dimensions of the array.
+Returns the dimensions of the array, or the length of a single axis when you pass an index.
 
 ```php
-public function shape(): array
+public function shape(?int $axis = null): array|int
 ```
 
-**Returns:** Array of integers representing size of each dimension
+With no argument (or `null`), you get the full shape as a list of positive integers. With an integer `$axis`, you get only that axis length. Negative indices count from the last dimension (`-1` is the last axis), matching how axis arguments work on reductions and similar methods. Requesting an axis index on a zero-dimensional array throws `IndexException`.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$axis` | `int\|null` | Optional. If omitted or `null`, return the full shape. If set, return the size of that axis only. |
+
+**Returns:** `list<int>` for the full shape, or `int` for one axis length.
 
 **Examples:**
 
 ```php
 $arr = NDArray::zeros([3, 4, 5]);
-echo $arr->shape();  // [3, 4, 5]
+$arr->shape();    // [3, 4, 5]
+$arr->shape(0);   // 3
+$arr->shape(-1);  // 5 (last dimension)
 
 $vector = NDArray::array([1, 2, 3]);
-echo $vector->shape();  // [3]
+$vector->shape();   // [3]
+$vector->shape(-1); // 3
 ```
 
 ---

--- a/docs/guide/fundamentals/understanding-arrays.md
+++ b/docs/guide/fundamentals/understanding-arrays.md
@@ -156,6 +156,11 @@ $arr = NDArray::array([
 
 $arr->shape();  // [2, 3]
                  // 2 rows, 3 columns
+
+// Single axis length (optional index; negative counts from the end)
+$arr->shape(0);   // 2
+$arr->shape(1);   // 3
+$arr->shape(-1);  // 3 — same as the last entry of shape()
 ```
 
 **Visualizing Dimensions:**

--- a/docs/guide/getting-started/numpy-migration.md
+++ b/docs/guide/getting-started/numpy-migration.md
@@ -31,6 +31,7 @@ NDArray PHP is designed to feel familiar to NumPy users while respecting PHP idi
 | NumPy | NDArray PHP | Notes |
 |-------|-------------|-------|
 | `arr.shape` | `$arr->shape()` | Method call in PHP |
+| `arr.shape[i]`, `arr.shape[-1]` | `$arr->shape($i)`, `$arr->shape(-1)` | One axis length; negative counts from last |
 | `arr.dtype` | `$arr->dtype()` | Returns DType enum |
 | `arr.ndim` | `$arr->ndim()` | |
 | `arr.size` | `$arr->size()` | |
@@ -242,6 +243,7 @@ mean = arr.mean()
 $shape = $arr->shape();
 $dtype = $arr->dtype();
 $mean = $arr->mean();
+$lastDim = $arr->shape(-1);  // like arr.shape[-1] in NumPy
 ```
 
 ### 3. No Operator Overloading in PHP

--- a/docs/guide/getting-started/quick-start.md
+++ b/docs/guide/getting-started/quick-start.md
@@ -101,6 +101,8 @@ print_r($arr->itemsize()); // 8 - bytes per element
 print_r($arr->nbytes());   // 48 - total bytes
 ```
 
+For a single axis length (for example the last dimension), pass an index: `$arr->shape(-1)` is `3` here. Negative indices count from the last dimension, consistent with `get()` and reduction `axis` arguments.
+
 ## Basic Operations
 
 ### Arithmetic

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,7 @@ Coming from NumPy? You'll feel right at home (with PHP syntax):
 |-------|-------------|
 | `np.array([1, 2, 3])` | `NDArray::array([1, 2, 3])` |
 | `arr.shape` | `$arr->shape()` |
+| `arr.shape[-1]` | `$arr->shape(-1)` |
 | `arr.sum()` | `$arr->sum()` |
 | `a + b` | `$a->add($b)` |
 | `a[0, 0]` | `$a['0,0']` |

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -2063,9 +2063,9 @@ namespace PhpMlKit\NDArray\Windows {
      * Piecewise linear, peaks at 1.0 at the center, 0.0 at both ends for `m > 1`.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function bartlett(int $m, bool $periodic = false): NDArray
     {
@@ -2079,9 +2079,9 @@ namespace PhpMlKit\NDArray\Windows {
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.42 - 0.5*cos(2πn/(m-1)) + 0.08*cos(4πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function blackman(int $m, bool $periodic = false): NDArray
     {
@@ -2094,9 +2094,9 @@ namespace PhpMlKit\NDArray\Windows {
      * Let {@code x = |2n/(m-1) - 1|}. For `m > 1`: {@code w(n) = (1-x)*cos(πx) + sin(πx)/π}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function bohman(int $m, bool $periodic = false): NDArray
     {
@@ -2109,9 +2109,9 @@ namespace PhpMlKit\NDArray\Windows {
      * All ones; no tapering.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function boxcar(int $m, bool $periodic = false): NDArray
     {
@@ -2124,9 +2124,9 @@ namespace PhpMlKit\NDArray\Windows {
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.54 - 0.46*cos(2πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function hamming(int $m, bool $periodic = false): NDArray
     {
@@ -2139,9 +2139,9 @@ namespace PhpMlKit\NDArray\Windows {
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.5 - 0.5*cos(2πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      *
      * @see hann()
      */
@@ -2154,9 +2154,9 @@ namespace PhpMlKit\NDArray\Windows {
      * Alias of {@see hanning()} — delegates to {@see NDArray::hann()}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function hann(int $m, bool $periodic = false): NDArray
     {
@@ -2169,10 +2169,10 @@ namespace PhpMlKit\NDArray\Windows {
      * Larger `beta` improves sidelobe attenuation at the cost of a wider main lobe.
      *
      * @param int   $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param float $beta     Shape parameter (main lobe vs sidelobe trade-off).
-     * @param bool  $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param float $beta     shape parameter (main lobe vs sidelobe trade-off)
+     * @param bool  $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function kaiser(int $m, float $beta, bool $periodic = false): NDArray
     {
@@ -2186,9 +2186,9 @@ namespace PhpMlKit\NDArray\Windows {
      * {@code sinc(x) = sin(πx)/(πx)} for {@code x ≠ 0}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function lanczos(int $m, bool $periodic = false): NDArray
     {
@@ -2201,9 +2201,9 @@ namespace PhpMlKit\NDArray\Windows {
      * Similar to Bartlett; endpoints are not forced to zero the same way.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     function triang(int $m, bool $periodic = false): NDArray
     {

--- a/src/NDArray.php
+++ b/src/NDArray.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray;
 
 use FFI\CData;
+use PhpMlKit\NDArray\Exceptions\IndexException;
 use PhpMlKit\NDArray\FFI\Lib;
 use PhpMlKit\NDArray\Traits\CanBePrinted;
 use PhpMlKit\NDArray\Traits\CreatesArrays;
@@ -78,13 +79,38 @@ class NDArray implements \ArrayAccess, \Stringable, \IteratorAggregate
     }
 
     /**
-     * Get shape.
+     * Shape tuple, or the length of one axis when `$axis` is given.
      *
-     * @return array<int>
+     * With no argument (or `null`), returns the full shape as a list. With an integer, returns
+     * the size of that axis only. Negative `$axis` counts from the last dimension (`-1` is the
+     * last axis), consistent with axis arguments elsewhere on this class.
+     *
+     * @param null|int $axis axis index into the shape vector (`0` … `ndim - 1`, or negative)
+     *
+     * @return ($axis is null ? list<int> : int)
+     *
+     * @throws IndexException If `$axis` is out of bounds, or if a scalar length is requested on
+     *                        a zero-dimensional array
      */
-    public function shape(): array
+    public function shape(?int $axis = null): array|int
     {
-        return $this->meta->shape;
+        if (null === $axis) {
+            return $this->meta->shape;
+        }
+
+        $ndim = $this->meta->ndim;
+        if (0 === $ndim) {
+            throw new IndexException('Cannot index shape of a zero-dimensional array');
+        }
+
+        $resolved = $axis < 0 ? $ndim + $axis : $axis;
+        if ($resolved < 0 || $resolved >= $ndim) {
+            throw new IndexException(
+                "Shape axis {$axis} is out of bounds for array with {$ndim} dimensions"
+            );
+        }
+
+        return $this->meta->shape[$resolved];
     }
 
     /**

--- a/src/Traits/HasWindowFunctions.php
+++ b/src/Traits/HasWindowFunctions.php
@@ -23,9 +23,9 @@ trait HasWindowFunctions
      * ends for `m > 1`. Tapers a segment with mild boundary rolloff.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function bartlett(int $m, bool $periodic = false): NDArray
     {
@@ -44,9 +44,9 @@ trait HasWindowFunctions
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.42 - 0.5*cos(2πn/(m-1)) + 0.08*cos(4πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function blackman(int $m, bool $periodic = false): NDArray
     {
@@ -65,9 +65,9 @@ trait HasWindowFunctions
      * Let {@code x = |2n/(m-1) - 1|}. For `m > 1`: {@code w(n) = (1-x)*cos(πx) + sin(πx)/π}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function bohman(int $m, bool $periodic = false): NDArray
     {
@@ -83,9 +83,9 @@ trait HasWindowFunctions
      * Boxcar (rectangular) window: all ones — equivalent to no tapering.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function boxcar(int $m, bool $periodic = false): NDArray
     {
@@ -104,9 +104,9 @@ trait HasWindowFunctions
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.54 - 0.46*cos(2πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function hamming(int $m, bool $periodic = false): NDArray
     {
@@ -125,9 +125,9 @@ trait HasWindowFunctions
      * For `m > 1` and `0 ≤ n ≤ m-1`: {@code w(n) = 0.5 - 0.5*cos(2πn/(m-1))}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      *
      * @see self::hann()
      */
@@ -145,9 +145,9 @@ trait HasWindowFunctions
      * Alias of {@see self::hanning()}: identical Hann window.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function hann(int $m, bool $periodic = false): NDArray
     {
@@ -159,10 +159,10 @@ trait HasWindowFunctions
      * (less spectral leakage) at the cost of a wider main lobe.
      *
      * @param int   $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param float $beta     Shape parameter controlling main-lobe width vs sidelobe level.
-     * @param bool  $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param float $beta     shape parameter controlling main-lobe width vs sidelobe level
+     * @param bool  $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function kaiser(int $m, float $beta, bool $periodic = false): NDArray
     {
@@ -181,9 +181,9 @@ trait HasWindowFunctions
      * {@code sinc(x) = sin(πx)/(πx)} for {@code x ≠ 0}.
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function lanczos(int $m, bool $periodic = false): NDArray
     {
@@ -200,9 +200,9 @@ trait HasWindowFunctions
      * zero in the same way (see Bartlett for the triangle with explicit zero endpoints).
      *
      * @param int  $m        Number of samples. `m = 0` → empty array; `m = 1` → `[1.0]`.
-     * @param bool $periodic If `true`, use the periodic variant; if `false`, symmetric (default).
+     * @param bool $periodic if `true`, use the periodic variant; if `false`, symmetric (default)
      *
-     * @return NDArray Float64, shape `[m]`.
+     * @return NDArray float64, shape `[m]`
      */
     public static function triang(int $m, bool $periodic = false): NDArray
     {

--- a/tests/Unit/NDArrayTest.php
+++ b/tests/Unit/NDArrayTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpMlKit\NDArray\Tests\Unit;
 
 use PhpMlKit\NDArray\DType;
+use PhpMlKit\NDArray\Exceptions\IndexException;
 use PhpMlKit\NDArray\Exceptions\ShapeException;
 use PhpMlKit\NDArray\NDArray;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -369,5 +370,61 @@ final class NDArrayTest extends TestCase
         $result = $arr->toArray();
 
         $this->assertSame($data, $result);
+    }
+
+    // =========================================================================
+    // shape() optional axis
+    // =========================================================================
+
+    public function testShapeNullEqualsOmitted(): void
+    {
+        $arr = NDArray::zeros([3, 4, 5]);
+
+        $this->assertSame([3, 4, 5], $arr->shape());
+        $this->assertSame([3, 4, 5], $arr->shape(null));
+    }
+
+    public function testShapeAxisPositiveAndNegative(): void
+    {
+        $arr = NDArray::zeros([3, 4, 5]);
+
+        $this->assertSame(3, $arr->shape(0));
+        $this->assertSame(4, $arr->shape(1));
+        $this->assertSame(5, $arr->shape(2));
+        $this->assertSame(5, $arr->shape(-1));
+        $this->assertSame(4, $arr->shape(-2));
+        $this->assertSame(3, $arr->shape(-3));
+    }
+
+    public function testShapeAxisOutOfBoundsThrows(): void
+    {
+        $arr = NDArray::zeros([2, 3]);
+
+        $this->expectException(IndexException::class);
+        $this->expectExceptionMessage('Shape axis 2 is out of bounds');
+
+        $arr->shape(2);
+    }
+
+    public function testShapeAxisNegativeOutOfBoundsThrows(): void
+    {
+        $arr = NDArray::zeros([2, 3]);
+
+        $this->expectException(IndexException::class);
+        $this->expectExceptionMessage('Shape axis -3 is out of bounds');
+
+        $arr->shape(-3);
+    }
+
+    public function testShapeAxisOnZeroDimensionalThrows(): void
+    {
+        $arr = NDArray::array([3.14], DType::Float64)->reshape([]);
+
+        $this->assertSame([], $arr->shape());
+
+        $this->expectException(IndexException::class);
+        $this->expectExceptionMessage('zero-dimensional');
+
+        $arr->shape(0);
     }
 }


### PR DESCRIPTION
This PR extends `NDArray::shape()` so callers can read the full shape as today or pass an axis index (including negative indices from the last dimension) to get a single dimension length, with clear errors for out-of-range axes and zero-dimensional arrays, plus tests and documentation updates.

### Motivation and Context
PHP only exposes the shape as a list, so reading the last dimension or a specific axis without extra indexing gymnastics is awkward compared to tuple-style access in other ecosystems. An optional axis argument keeps the default call identical while giving a small, discoverable API that matches how axis indices already work elsewhere on the class.

What’s `Changed`

- `shape(?int $axis = null)` returning the full `list<int>` when omitted or null, or one int length when an axis is given.
- Negative axis indices resolved from the last dimension, with `IndexException` on out-of-bounds axis indices or when indexing shape on a zero-dimensional array.
- PHPDoc with a conditional return template for static analyzers.
- Unit tests covering null vs omitted behavior, positive and negative axes, bounds failures, and the zero-dimensional case.
- User-facing docs updated on the NDArray class page, API quick reference, landing comparison table, fundamentals and quick-start guides, and the NumPy migration guide where shape is discussed.

Breaking `Changes`
None. Existing `shape()` calls without arguments behave the same.