### PR TITLE
feat: add conditional return types for axis-dependent reduction methods

### DIFF
--- a/src/Traits/HasLinearAlgebra.php
+++ b/src/Traits/HasLinearAlgebra.php
@@ -31,6 +31,8 @@ trait HasLinearAlgebra
      * @param null|float|int|string $ord      Norm order
      * @param null|int              $axis     Reduction axis. If null, reduces all elements
      * @param bool                  $keepdims Keep reduced axis with size 1 (axis mode only)
+     *
+     * @return ($axis is null ? float : NDArray)
      */
     public function norm(float|int|string|null $ord = null, ?int $axis = null, bool $keepdims = false): float|NDArray
     {

--- a/src/Traits/HasReductions.php
+++ b/src/Traits/HasReductions.php
@@ -25,7 +25,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to sum. If null, sum over all elements.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? Complex|float|int : NDArray)
      */
     public function sum(?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
     {
@@ -42,7 +42,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to compute mean. If null, compute mean of all elements.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return Complex|float|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? Complex|float : NDArray)
      */
     public function mean(?int $axis = null, bool $keepdims = false): Complex|float|NDArray
     {
@@ -59,7 +59,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to find minimum. If null, find minimum of all elements.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? Complex|float|int : NDArray)
      */
     public function min(?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
     {
@@ -76,7 +76,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to find maximum. If null, find maximum of all elements.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? Complex|float|int : NDArray)
      */
     public function max(?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
     {
@@ -93,7 +93,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to find argmin. If null, find argmin of flattened array.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return int|NDArray scalar index if axis is null, otherwise an NDArray of indices
+     * @return ($axis is null ? int : NDArray)
      */
     public function argmin(?int $axis = null, bool $keepdims = false): int|NDArray
     {
@@ -110,7 +110,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to find argmax. If null, find argmax of flattened array.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return int|NDArray scalar index if axis is null, otherwise an NDArray of indices
+     * @return ($axis is null ? int : NDArray)
      */
     public function argmax(?int $axis = null, bool $keepdims = false): int|NDArray
     {
@@ -188,7 +188,7 @@ trait HasReductions
      * @param null|int $axis     Axis along which to compute product. If null, compute product of all elements.
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return Complex|float|int|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? Complex|float|int : NDArray)
      */
     public function product(?int $axis = null, bool $keepdims = false): Complex|float|int|NDArray
     {
@@ -234,7 +234,7 @@ trait HasReductions
      * @param int      $ddof     delta degrees of freedom (0 for population, 1 for sample)
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return float|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? float : NDArray)
      */
     public function var(?int $axis = null, int $ddof = 0, bool $keepdims = false): float|NDArray
     {
@@ -252,7 +252,7 @@ trait HasReductions
      * @param int      $ddof     delta degrees of freedom (0 for population, 1 for sample)
      * @param bool     $keepdims if true, the reduced axis is retained with size 1
      *
-     * @return float|NDArray scalar if axis is null, otherwise an NDArray
+     * @return ($axis is null ? float : NDArray)
      */
     public function std(?int $axis = null, int $ddof = 0, bool $keepdims = false): float|NDArray
     {


### PR DESCRIPTION
This PR adds PHPStan conditional return type annotations to reduction and norm methods whose return type depends on whether `$axis` is null.

## Motivation and Context

When calling methods like `$arr->sum()` with `$axis = null`, the return is always a scalar (Complex|float|int), but the union return type `Complex|float|int|NDArray` forces static analysis tools like PHPStan to require type narrowing before using the result. Conditional return types allow tools to infer the correct type based on the `$axis` argument value, eliminating unnecessary boilerplate assertions.

## What's Changed

- Added `@return ($axis is null ? <scalar> : NDArray)` PHPDoc annotations to `sum`, `mean`, `min`, `max`, `argmin`, `argmax`, `product`, `var`, `std` in `HasReductions` trait
- Added `@return ($axis is null ? float : NDArray)` PHPDoc annotation to `norm` in `HasLinearAlgebra` trait

## Breaking Changes

None.
