### PR TITLE
fix: fromArray now actually uses the provided shape parameter

### DIFF
--- a/src/Traits/CreatesArrays.php
+++ b/src/Traits/CreatesArrays.php
@@ -167,8 +167,20 @@ trait CreatesArrays
     public static function fromArray(array $data, ?array $shape = null, ?DType $dtype = null): self
     {
         $shape ??= self::inferShape($data);
+        $flatData = self::flattenArray($data);
 
-        return self::array($data, $dtype);
+        if (empty($flatData)) {
+            throw new ShapeException('Cannot create array from empty data');
+        }
+
+        $dtype ??= DType::fromArray($data);
+
+        $lib = Lib::get();
+        $len = \count($flatData);
+
+        $handle = self::createTyped($lib, $dtype, $flatData, $shape, $len);
+
+        return new self($handle, new ArrayMetadata($shape), $dtype);
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where `fromArray()` silently ignored its `$shape` parameter.

## Motivation and Context

`fromArray()` accepts an optional `$shape` parameter but delegated to `array()`, which always infers shape from the input data. Calling `NDArray::fromArray([1, 2, 3, 4, 5, 6], [2, 3])` would create a 1D array of shape `[6]` instead of the requested `[2, 3]`, with no warning or error.

## What's Changed

- `fromArray()` now duplicates `array()`'s creation logic instead of proxying to it, using the provided shape when given and only inferring from data as a fallback

## Breaking Changes

None.