### PR TITLE
fix: make topk() return numerically-keyed tuple for consistency

### DIFF
--- a/docs/api/sorting-searching.md
+++ b/docs/api/sorting-searching.md
@@ -184,7 +184,7 @@ Return top-k values and indices like PyTorch topk.
 
 ### Returns
 
-- `array` - Array with keys 'values' (NDArray) and 'indices' (NDArray).
+- `array{0: NDArray, 1: NDArray}` - A numerically-indexed array where element 0 is the values NDArray and element 1 is the indices NDArray.
 
 ### Raises
 
@@ -194,17 +194,17 @@ Return top-k values and indices like PyTorch topk.
 
 ```php
 $arr = NDArray::array([3, 1, 4, 1, 5]);
-$result = $arr->topk(3);
+[$values, $indices] = $arr->topk(3);
 
-print_r($result['values']->toArray());
+print_r($values->toArray());
 // Output: [5, 4, 3]
 
-print_r($result['indices']->toArray());
+print_r($indices->toArray());
 // Output: [4, 2, 0]
 
 // Smallest values
-$result = $arr->topk(3, largest: false);
-print_r($result['values']->toArray());
+[$values, $indices] = $arr->topk(3, largest: false);
+print_r($values->toArray());
 // Output: [1, 1, 3]
 ```
 

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -1151,7 +1151,7 @@ namespace PhpMlKit\NDArray {
      * @param bool     $sorted  If true, keep selected values sorted by rank
      * @param SortKind $kind    Sorting algorithm
      *
-     * @return array{values: NDArray, indices: NDArray}
+     * @return array{0: NDArray, 1: NDArray} [values, indices]
      */
     function topk(
         NDArray $a,

--- a/src/Traits/HasReductions.php
+++ b/src/Traits/HasReductions.php
@@ -162,7 +162,7 @@ trait HasReductions
      * @param bool     $sorted  If true, keep selected values sorted by rank
      * @param SortKind $kind    Sorting algorithm
      *
-     * @return array{values: NDArray, indices: NDArray}
+     * @return array{0: NDArray, 1: NDArray} [values, indices]
      */
     public function topk(
         int $k,
@@ -323,7 +323,7 @@ trait HasReductions
     /**
      * Perform topk along axis.
      *
-     * @return array{values: NDArray, indices: NDArray}
+     * @return array{0: NDArray, 1: NDArray} [values, indices]
      */
     private function topkAxisOp(int $k, int $axis, bool $largest, bool $sorted, SortKind $kind): array
     {
@@ -354,15 +354,15 @@ trait HasReductions
         $outShape = $lib->readSizeTArray($outShapeBuf, $ndim);
 
         return [
-            'values' => new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
-            'indices' => new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
+            new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
+            new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
         ];
     }
 
     /**
      * Perform topk over flattened array.
      *
-     * @return array{values: NDArray, indices: NDArray}
+     * @return array{0: NDArray, 1: NDArray} [values, indices]
      */
     private function topkFlatOp(int $k, bool $largest, bool $sorted, SortKind $kind): array
     {
@@ -390,8 +390,8 @@ trait HasReductions
         $outShape = [(int) $outShapeBuf[0]];
 
         return [
-            'values' => new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
-            'indices' => new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
+            new NDArray($outValuesHandle, new ArrayMetadata($outShape), $this->dtype),
+            new NDArray($outIndicesHandle, new ArrayMetadata($outShape), DType::Int64),
         ];
     }
 }

--- a/tests/Unit/SortingTest.php
+++ b/tests/Unit/SortingTest.php
@@ -146,10 +146,10 @@ final class SortingTest extends TestCase
         $a = NDArray::array([[1, 7, 3, 5], [9, 2, 8, 4]], DType::Int32);
         $topk = $a->topk(2);
 
-        $this->assertSame([2, 2], $topk['values']->shape());
-        $this->assertSame([[7, 5], [9, 8]], $topk['values']->toArray());
-        $this->assertSame([[1, 3], [0, 2]], $topk['indices']->toArray());
-        $this->assertSame(DType::Int64, $topk['indices']->dtype());
+        $this->assertSame([2, 2], $topk[0]->shape());
+        $this->assertSame([[7, 5], [9, 8]], $topk[0]->toArray());
+        $this->assertSame([[1, 3], [0, 2]], $topk[1]->toArray());
+        $this->assertSame(DType::Int64, $topk[1]->dtype());
     }
 
     public function testTopkSmallestAlongAxis(): void
@@ -157,8 +157,8 @@ final class SortingTest extends TestCase
         $a = NDArray::array([[1, 7, 3, 5], [9, 2, 8, 4]], DType::Int32);
         $topk = $a->topk(2, axis: 1, largest: false, kind: SortKind::MergeSort);
 
-        $this->assertSame([[1, 3], [2, 4]], $topk['values']->toArray());
-        $this->assertSame([[0, 2], [1, 3]], $topk['indices']->toArray());
+        $this->assertSame([[1, 3], [2, 4]], $topk[0]->toArray());
+        $this->assertSame([[0, 2], [1, 3]], $topk[1]->toArray());
     }
 
     public function testTopkFlattened(): void
@@ -166,9 +166,9 @@ final class SortingTest extends TestCase
         $a = NDArray::array([[1, 7, 3], [5, 9, 2]], DType::Int32);
         $topk = $a->topk(3, axis: null, kind: SortKind::HeapSort);
 
-        $this->assertSame([3], $topk['values']->shape());
-        $this->assertSame([9, 7, 5], $topk['values']->toArray());
-        $this->assertSame([4, 1, 3], $topk['indices']->toArray());
+        $this->assertSame([3], $topk[0]->shape());
+        $this->assertSame([9, 7, 5], $topk[0]->toArray());
+        $this->assertSame([4, 1, 3], $topk[1]->toArray());
     }
 
     public function testTopkAllKindsConsistentValues(): void
@@ -179,7 +179,7 @@ final class SortingTest extends TestCase
 
         foreach ($kinds as $kind) {
             $topk = $a->topk(3, axis: null, kind: $kind);
-            $this->assertSame($expected, $topk['values']->toArray(), "kind={$kind->name} failed");
+            $this->assertSame($expected, $topk[0]->toArray(), "kind={$kind->name} failed");
         }
     }
 
@@ -189,8 +189,8 @@ final class SortingTest extends TestCase
         $topk = $a->topk(3, axis: null, largest: true, sorted: false);
 
         // top-3 set is {7, 6, 4}; sorted=false returns them in source index order
-        $this->assertSame([4, 7, 6], $topk['values']->toArray());
-        $this->assertSame([0, 2, 4], $topk['indices']->toArray());
+        $this->assertSame([4, 7, 6], $topk[0]->toArray());
+        $this->assertSame([0, 2, 4], $topk[1]->toArray());
     }
 
     public function testTopkOutOfBoundsThrows(): void
@@ -284,8 +284,8 @@ final class SortingTest extends TestCase
 
         $topk = $view->topk(2, axis: null);
 
-        $this->assertSame([2], $topk['values']->shape());
-        $this->assertSame([3, 2], $topk['values']->toArray());
-        $this->assertSame([0, 2], $topk['indices']->toArray());
+        $this->assertSame([2], $topk[0]->shape());
+        $this->assertSame([3, 2], $topk[0]->toArray());
+        $this->assertSame([0, 2], $topk[1]->toArray());
     }
 }


### PR DESCRIPTION
This PR changes `topk()` from returning string-keyed arrays (`['values' => ..., 'indices' => ...]`) to numerically-keyed arrays (`[$values, $indices]`) to match the convention used by every other multi-NDArray return in the library.

## Motivation and Context

`topk()` was the only method returning a string-keyed tuple (`['values' => NDArray, 'indices' => NDArray]`). All other multi-NDArray returns — `svd()`, `qr()`, `eig()`, `eigh()`, `lstsq()`, `split()`, `vsplit()`, `hsplit()`, `meshgrid()` — use numerical positional keys. This inconsistency meant callers had to remember different destructuring patterns depending on the method. The new signature matches NumPy and PyTorch semantics where destructuring is natural: `[$values, $indices] = $arr->topk(3)`.

## What's Changed

- `topk()` and its private helpers (`topkAxisOp`, `topkFlatOp`) now return `[NDArray, NDArray]` instead of `['values' => NDArray, 'indices' => NDArray]`
- Updated PHPDoc `@return` annotations from `array{values: NDArray, indices: NDArray}` to `array{0: NDArray, 1: NDArray}`
- Updated all tests to use positional destructuring (`$topk[0]`/`$topk[1]` instead of `$topk['values']`/`$topk['indices']`)
- Updated API documentation examples

## Breaking Changes

**Yes.** Anyone relying on `$result['values']` or `$result['indices']` to access topk results will need to update to `$result[0]`/`$result[1]` or destructure with `[$values, $indices] = $arr->topk(...)`.